### PR TITLE
Context-based urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ bower_components
 *.log
 /kekkonen.iml
 /.idea
+.classpath

--- a/test/kekkonen/ring_test.clj
+++ b/test/kekkonen/ring_test.clj
@@ -43,7 +43,11 @@
 
     (fact "request can be read as-is"
       (let [request {:uri "/api/snoop" :request-method :post}]
-        (app request) => (ok request)))))
+        (app request) => (ok request)))
+    
+    (fact "handles request within context"
+      (let [request {:uri "/somecontext/api/ping" :request-method :post :context "/somecontext"}]
+        (app request) => "pong"))))
 
 (p/defnk ^:handler plus
   [[:request [:query-params x :- s/Int, y :- s/Int]]]


### PR DESCRIPTION
When deploying a kekkonen-based app in a sub-url (e.g. in Tomcat), it did
not recognize the uri's because the context url was added.  This commit
fixes that.