### PR TITLE
Swagger options identical to compojure-api

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,26 @@
 
 * *BREAKING*: Removed type-level interceptors from ring-adapter.
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
+* *BREAKING*: top-level swagger options are now in align to the compojure-api:
+  * Fixes [#22](https://github.com/metosin/kekkonen/issues/22)
+
+### Old
+
+```clj
+{:swagger {:info {:title "Kekkonen"}}
+ :swagger-ui {:jsonEdit true}})
+```
+
+### New
+
+```clj
+{:swagger
+ {:spec "/swagger.json"
+  :ui "/api-docs"
+  :options {:ui {:jsonEdit true}
+            :spec {:ignore-missing-mappings? false}}
+  :data {:info {:title "Kekkonen"}}}}
+```
 
 * updated dependencies:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
 * *BREAKING*: top-level swagger options are now in align to the compojure-api:
   * Fixes [#22](https://github.com/metosin/kekkonen/issues/22)
+  * By default, `api`s don't bind swagger-spec & swagger-ui, use `:spec` & `:ui` options
 
 ### Old
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 ## 0.3.0-SNAPSHOT
 
-* *BREAKING*: Removed type-level interceptors from ring-adapter.
+* **BREAKING**: Removed type-level interceptors from ring-adapter.
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
-* *BREAKING*: top-level swagger options are now in align to the compojure-api:
+* **BREAKING**: top-level swagger options are now in align to the compojure-api:
   * Fixes [#22](https://github.com/metosin/kekkonen/issues/22)
   * By default, `api`s don't bind swagger-spec & swagger-ui, use `:spec` & `:ui` options
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Mostly written as [issues](https://github.com/metosin/kekkonen/issues). Biggest 
   (success {:result (+ x y)}))
 
 (defnk ^:command inc!
-  [[:components counter]]
+  [counter]
   (success {:result (swap! counter inc)}))
 
 ;;
@@ -146,10 +146,12 @@ Mostly written as [issues](https://github.com/metosin/kekkonen/issues). Biggest 
 
 (def app
   (cqrs-api
-    {:swagger {:info {:title "Kekkonen example"}}
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
+               :data {:info {:title "Kekkonen example"}}}
      :core {:handlers {:api {:pizza #'echo-pizza
                              :example [#'ping #'inc! #'plus]}}
-            :context {:components {:counter (atom 0)}}}}))
+            :context {:counter (atom 0)}}}))
 
 ;;
 ;; Start it

--- a/dev-src/example/api.clj
+++ b/dev-src/example/api.clj
@@ -41,7 +41,9 @@
 
 (def app
   (cqrs-api
-    {:swagger {:data {:info {:title "Kekkonen example"}}}
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
+               :data {:info {:title "Kekkonen example"}}}
      :core {:handlers {:api {:pizza #'echo-pizza
                              :sample [#'ping #'inc! #'plus]}}
             :context {:components {:counter (atom 0)}}}}))

--- a/dev-src/example/api.clj
+++ b/dev-src/example/api.clj
@@ -41,7 +41,7 @@
 
 (def app
   (cqrs-api
-    {:swagger {:info {:title "Kekkonen example"}}
+    {:swagger {:data {:info {:title "Kekkonen example"}}}
      :core {:handlers {:api {:pizza #'echo-pizza
                              :sample [#'ping #'inc! #'plus]}}
             :context {:components {:counter (atom 0)}}}}))

--- a/dev-src/example/cqrs.clj
+++ b/dev-src/example/cqrs.clj
@@ -105,8 +105,8 @@
 
 (def app
   (cqrs-api
-    {:swagger {:spec "/swagger.json"
-               :ui "/api-docs"
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
                :data {:info {:title "Kekkonen"}}}
      :core {:handlers {:api {:item [#'get-items #'add-item #'reset-items]
                              :calculator [#'plus #'times #'increment]

--- a/dev-src/example/cqrs.clj
+++ b/dev-src/example/cqrs.clj
@@ -105,7 +105,9 @@
 
 (def app
   (cqrs-api
-    {:swagger {:info {:title "Kekkonen"}}
+    {:swagger {:spec "/swagger.json"
+               :ui "/api-docs"
+               :data {:info {:title "Kekkonen"}}}
      :core {:handlers {:api {:item [#'get-items #'add-item #'reset-items]
                              :calculator [#'plus #'times #'increment]
                              :security #'get-user

--- a/dev-src/example/github/github.clj
+++ b/dev-src/example/github/github.clj
@@ -112,7 +112,9 @@
 
 (def app
   (cqrs-api
-    {:swagger {:data {:info {:title "Kekkonen"
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
+               :data {:info {:title "Kekkonen"
                              :version "1.0"}}}
      :core {:handlers {:api {:github [#'get-repository
                                       #'list-repositorys

--- a/dev-src/example/github/github.clj
+++ b/dev-src/example/github/github.clj
@@ -112,8 +112,8 @@
 
 (def app
   (cqrs-api
-    {:swagger {:info {:title "Kekkonen"
-                      :version "1.0"}}
+    {:swagger {:data {:info {:title "Kekkonen"
+                             :version "1.0"}}}
      :core {:handlers {:api {:github [#'get-repository
                                       #'list-repositorys
                                       #'fork

--- a/examples/component/src/sample/handler.clj
+++ b/examples/component/src/sample/handler.clj
@@ -38,7 +38,9 @@
 
 (p/defnk create [[:state counter]]
   (cqrs-api
-    {:swagger {:data {:info {:title "Kekkonen with Component"
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
+               :data {:info {:title "Kekkonen with Component"
                              :description "created with http://kekkonen.io"}}}
      :core {:handlers {:api {:pizza #'echo-pizza
                              :math [#'inc! #'plus]

--- a/examples/component/src/sample/handler.clj
+++ b/examples/component/src/sample/handler.clj
@@ -38,8 +38,8 @@
 
 (p/defnk create [[:state counter]]
   (cqrs-api
-    {:swagger {:info {:title "Kekkonen with Component"
-                      :description "created with http://kekkonen.io"}}
+    {:swagger {:data {:info {:title "Kekkonen with Component"
+                             :description "created with http://kekkonen.io"}}}
      :core {:handlers {:api {:pizza #'echo-pizza
                              :math [#'inc! #'plus]
                              :ping #'ping}}

--- a/src/kekkonen/api.clj
+++ b/src/kekkonen/api.clj
@@ -20,10 +20,7 @@
    :api {:handlers r/+kekkonen-handlers+}
    :ring r/+default-options+
    :mw mw/+default-options+
-   ;; TODO: don't bind swagger.json & swagger-ui by default?
-   :swagger {:spec "/swagger.json"
-             :ui "/"
-             :data {:info {:title "Kekkonen API"
+   :swagger {:data {:info {:title "Kekkonen API"
                            :version "0.0.1"}}}})
 
 (defn api [options]

--- a/src/kekkonen/api.clj
+++ b/src/kekkonen/api.clj
@@ -11,8 +11,7 @@
    (s/optional-key :api) {:handlers k/KeywordMap}
    (s/optional-key :ring) r/Options
    (s/optional-key :mw) k/KeywordMap
-   (s/optional-key :swagger) k/KeywordMap
-   (s/optional-key :swagger-ui) k/KeywordMap})
+   (s/optional-key :swagger) ks/Options})
 
 (s/def +default-options+ :- Options
   {:core (-> k/+default-options+
@@ -21,18 +20,24 @@
    :api {:handlers r/+kekkonen-handlers+}
    :ring r/+default-options+
    :mw mw/+default-options+
-   :swagger {:info {:title "Kekkonen API"}}
-   :swagger-ui ks/+default-swagger-ui-options+})
+   ;; TODO: don't bind swagger.json & swagger-ui by default?
+   :swagger {:spec "/swagger.json"
+             :ui "/"
+             :data {:info {:title "Kekkonen API"
+                           :version "0.0.1"}}}})
 
 (defn api [options]
   (s/with-fn-validation
     (let [options (s/validate Options (kc/deep-merge-map-like +default-options+ options))
-          swagger (merge (:swagger options) (mw/api-info (:mw options)))
-          dispatcher (-> (k/dispatcher (:core options))
-                         (k/inject (-> options :api :handlers))
-                         (k/inject (ks/swagger-handler swagger options)))]
+          api-handlers (-> options :api :handlers)
+          swagger-data (merge (-> options :swagger :data) (mw/api-info (:mw options)))
+          swagger-options (-> options :swagger)
+          swagger-handler (ks/swagger-handler swagger-data swagger-options)
+          dispatcher (cond-> (k/dispatcher (:core options))
+                             api-handlers (k/inject api-handlers)
+                             swagger-handler (k/inject swagger-handler))]
       (mw/wrap-api
         (r/routes
           [(r/ring-handler dispatcher (:ring options))
-           (ks/swagger-ui (:swagger-ui options))])
+           (ks/swagger-ui swagger-options)])
         (:mw options)))))

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -594,6 +594,7 @@
           :no-doc nil
           ;; TODO: should this be defined in kekkonen.ring?
           :responses nil}})
+
 (s/defn dispatcher :- Dispatcher
   "Creates a Dispatcher"
   [options :- Options]
@@ -618,7 +619,7 @@
 
 (s/defn inject
   "Injects handlers into an existing Dispatcher"
-  [dispatcher :- Dispatcher, handlers]
+  [dispatcher :- Dispatcher, handlers :- (s/constrained s/Any (complement nil?) 'not-nil)]
   (if handlers
     (let [handler (collect-and-enrich
                     (merge dispatcher {:handlers handlers :type-resolver any-type-resolver}) true)]

--- a/src/kekkonen/cqrs.clj
+++ b/src/kekkonen/cqrs.clj
@@ -47,7 +47,7 @@
   (ka/api
     (kc/deep-merge-map-like
       {:core {:type-resolver (k/type-resolver :command :query)}
-       :swagger {:info {:title "Kekkonen CQRS API"}}
+       :swagger {:data {:info {:title "Kekkonen CQRS API"}}}
        :ring {:types {:query {:methods #{:get}
                               :parameters {[:data] [:request :query-params]}}
                       :command {:methods #{:post}

--- a/src/kekkonen/http.clj
+++ b/src/kekkonen/http.clj
@@ -9,7 +9,7 @@
   (ka/api
     (kc/deep-merge-map-like
       {:core {:type-resolver (k/type-resolver :get :head :patch :delete :options :post :put :any)}
-       :swagger {:info {:title "Kekkonen HTTP API"}}
+       :swagger {:data {:info {:title "Kekkonen HTTP API"}}}
        :ring {:types {:get {:methods #{:get}}
                       :head {:methods #{:head}}
                       :patch {:methods #{:patch}}

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -167,8 +167,8 @@
 
 (s/defn routes :- k/Function
   "Creates a ring handler of multiples handlers, matches in order."
-  [ring-handlers :- [k/Function]]
-  (apply some-fn ring-handlers))
+  [ring-handlers :- [(s/maybe k/Function)]]
+  (apply some-fn (keep identity ring-handlers)))
 
 (s/defn match
   "Creates a ring-handler for given uri & request-method"

--- a/src/kekkonen/swagger.clj
+++ b/src/kekkonen/swagger.clj
@@ -65,7 +65,9 @@
     (assoc swagger :basePath context)
     swagger))
 
-(defn swagger-handler [swagger options]
+(defn swagger-handler
+  "Creates a handler, that serves the swagger-spec"
+  [swagger options]
   (if-let [spec (:spec options)]
     (k/handler
       {:type :kekkonen.ring/handler

--- a/test/kekkonen/api_test.clj
+++ b/test/kekkonen/api_test.clj
@@ -21,7 +21,9 @@
       context)))
 
 (facts "api-test"
-  (let [app (api {:core {:handlers {:api {:public [#'plus #'nada]
+  (let [app (api {:swagger {:ui "/api-docs"
+                            :spec "/swagger.json"}
+                  :core {:handlers {:api {:public [#'plus #'nada]
                                           secret-ns #'plus}}
                          :meta {::role require-role}}})]
 
@@ -294,24 +296,17 @@
                        {:/api/secret/plus anything})}))))
 
     (fact "swagger-ui"
-      (let [response (app {:uri "/" :request-method :get})]
+      (let [response (app {:uri "/api-docs" :request-method :get})]
         response => (contains
                       {:status 302
                        :body ""
                        :headers (contains
-                                  {"Location" "/index.html"})})))))
+                                  {"Location" "/api-docs/index.html"})})))))
 
 (facts "swagger-options"
 
-  (fact "ui & spec are set to /swagger.json & / by default"
+  (fact "ui & spec are not set by default"
     (let [app (api {:core {:handlers {:api #'plus}}})]
-
-      (app {:uri "/swagger.json", :request-method :get}) => ok?
-      (app {:uri "/index.html", :request-method :get}) => ok?))
-
-  (fact "without ui & spec"
-    (let [app (api {:swagger {:spec nil, :ui nil}
-                    :core {:handlers {:api #'plus}}})]
 
       (app {:uri "/swagger.json", :request-method :get}) => not-found?
       (app {:uri "/", :request-method :get}) => not-found?))

--- a/test/kekkonen/api_test.clj
+++ b/test/kekkonen/api_test.clj
@@ -301,6 +301,28 @@
                        :headers (contains
                                   {"Location" "/index.html"})})))))
 
+(facts "swagger-options"
+
+  (fact "ui & spec are set to /swagger.json & / by default"
+    (let [app (api {:core {:handlers {:api #'plus}}})]
+
+      (app {:uri "/swagger.json", :request-method :get}) => ok?
+      (app {:uri "/index.html", :request-method :get}) => ok?))
+
+  (fact "without ui & spec"
+    (let [app (api {:swagger {:spec nil, :ui nil}
+                    :core {:handlers {:api #'plus}}})]
+
+      (app {:uri "/swagger.json", :request-method :get}) => not-found?
+      (app {:uri "/", :request-method :get}) => not-found?))
+
+  (fact "with ui & spec"
+    (let [app (api {:swagger {:spec "/swagger.json", :ui "/api-docs"}
+                    :core {:handlers {:api #'plus}}})]
+
+      (app {:uri "/swagger.json", :request-method :get}) => ok?
+      (app {:uri "/api-docs/index.html", :request-method :get}) => ok?)))
+
 (facts "api-meta"
   (fact "meta can be presented as maps or vector of tuples"
     (api {:core {:handlers {secret-ns [#'nada]}, :meta {::role require-role}}})

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -950,14 +950,20 @@
     (fact "going meta boing boing"
       (k/invoke d :api/names) => #{:dispatcher :handler :names})))
 
-(fact "handlers can be injected into existing dispatcher"
-  (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
-              (k/inject (k/handler {:name :ping} identity)))]
-    d => (contains
-           {:handlers
-            (just
-              {:api/test anything
-               :ping anything})})))
+(fact "injecting handlers"
+
+  (fact "handlers can be injected"
+    (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+                (k/inject (k/handler {:name :ping} identity)))]
+      d => (contains
+             {:handlers
+              (just
+                {:api/test anything
+                 :ping anything})})))
+
+  (fact "injecting nil handlers fails"
+    (-> (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+        (k/inject nil)) => schema-error?))
 
 (facts "coercion-matcher"
   (let [PositiveInt (s/both s/Int (s/pred pos? 'positive))

--- a/test/kekkonen/midje.clj
+++ b/test/kekkonen/midje.clj
@@ -1,6 +1,7 @@
 (ns kekkonen.midje
   (:require [midje.util.exceptions :as e]
             [kekkonen.core :as k]
+            [schema.core :as s]
             [cheshire.core :as c]))
 
 (defn throws?
@@ -14,6 +15,7 @@
          (not (nil? x))
          (= mdata m))))))
 
+(def schema-error? (throws? {:type ::s/error}))
 (def missing-route? (throws? {:type ::k/dispatch}))
 (def input-coercion-error? (throws? {:type ::k/request}))
 (def output-coercion-error? (throws? {:type ::k/response}))

--- a/test/kekkonen/ring_test.clj
+++ b/test/kekkonen/ring_test.clj
@@ -44,7 +44,7 @@
     (fact "request can be read as-is"
       (let [request {:uri "/api/snoop" :request-method :post}]
         (app request) => (ok request)))
-    
+
     (fact "handles request within context"
       (let [request {:uri "/somecontext/api/ping" :request-method :post :context "/somecontext"}]
         (app request) => "pong"))))

--- a/test/kekkonen/swagger_test.clj
+++ b/test/kekkonen/swagger_test.clj
@@ -58,10 +58,10 @@
                      (k/dispatcher {:handlers {:api {:admin #'echo}}})
                      (partial #'r/attach-ring-meta r/+default-options+))
         swagger-handler (ks/swagger-handler {} {:spec "swagger.json", :info {:version "1.2.3"}})]
-    (against-background [(k/get-dispatcher anything) => dispatcher]
 
-                        (fact "generates swagger json"
-                          (swagger-handler {}) => (contains {:body (contains {:paths seq})})))
+    (against-background [(k/get-dispatcher anything) => dispatcher]
+      (fact "generates swagger json"
+        (swagger-handler {}) => (contains {:body (contains {:paths seq})})))
 
     (fact "extracts swagger basePath from request context"
       (let [context-path "/testpath"]


### PR DESCRIPTION
* **BREAKING**: top-level swagger options are now in align to the compojure-api:
  * Fixes [#22](https://github.com/metosin/kekkonen/issues/22)
  * By default, `api`s don't bind swagger-spec & swagger-ui, use `:spec` & `:ui` options

### Old

```clj
{:swagger {:info {:title "Kekkonen"}}
 :swagger-ui {:jsonEdit true}})
```

### New

```clj
{:swagger
 {:spec "/swagger.json"
  :ui "/api-docs"
  :options {:ui {:jsonEdit true}
            :spec {:ignore-missing-mappings? false}}
  :data {:info {:title "Kekkonen"}}}}
```