### PR TITLE
Towards fully data-driven

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,15 @@
   :data {:info {:title "Kekkonen"}}}}
 ```
 
+* **BREAKING**: Handler dispatch function is now `:handle` instead of `:function`
+* Handlers can be defined via a single map with `:handle` key for the dispatch
+
+```clj
+(k/handler
+  {:name "hello"
+   :handle (constantly "hello")})
+```
+
 * updated dependencies:
 
 ```clj

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,7 +39,7 @@
 [prismatic/schema "1.1.1"] is available but we use "1.1.0"
 [prismatic/plumbing "0.5.3"] is available but we use "0.5.2"
 [metosin/ring-swagger "0.22.7"] is available but we use "0.22.6"
-[clj-http "3.0.1"] is available but we use "2.1.0"
+[clj-http "3.1.0"] available but we use "2.1.0"
 ```
 
 ## 0.2.0 (29.3.2016)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Quickstart: `lein new kekkonen kakkonen`
 
 (def dispatcher
   (k/dispatcher
-    {:handlers {:api (k/handler {:name :hello, :handler (constantly "hello world"))}}}))
+    {:handlers {:api (k/handler {:name :hello, :handle (constantly "hello world"))}}}))
 
 (k/invoke dispatcher :api/hello)
 ; => "hello world"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Quickstart: `lein new kekkonen kakkonen`
 
 (def dispatcher
   (k/dispatcher
-    {:handlers {:api (k/handler {:name :hello} (constantly "hello world"))}}))
+    {:handlers {:api (k/handler {:name :hello, :handler (constantly "hello world"))}}}))
 
 (k/invoke dispatcher :api/hello)
 ; => "hello world"

--- a/dev-src/example/client.clj
+++ b/dev-src/example/client.clj
@@ -11,9 +11,9 @@
 ; simplest thing that works
 (def hello-world
   (k/handler
-    {:name "hello-world"}
-    (fn [_]
-      "hello world.")))
+    {:name "hello-world"
+     :handler (fn [_]
+                "hello world.")}))
 
 (hello-world {})
 
@@ -22,9 +22,9 @@
   (k/handler
     {:description "this is a handler for echoing data"
      :name :echo
-     :summary "echoes data"}
-    (fn [{:keys [data]}]
-      data)))
+     :summary "echoes data"
+     :handler (fn [{:keys [data]}]
+                data)}))
 
 (echo {:data {:name "tommi"}})
 
@@ -33,9 +33,9 @@
   (k/handler
     {:description "fnk echo"
      :name :fnkecho
-     :summery "echoes data"}
-    (p/fnk [[:data x :- s/Int, y :- s/Int]]
-      (+ x y))))
+     :summery "echoes data"
+     :handler (p/fnk [[:data x :- s/Int, y :- s/Int]]
+                (+ x y))}))
 
 (plus {:data {:x 1, :y 2}})
 
@@ -66,14 +66,13 @@
                            :others [echo
                                     hello-world]
                            :public (k/handler
-                                     {:name :ping}
-                                     (p/fnk []
-                                       :pong))}}
+                                     {:name :ping
+                                      :handler (p/fnk [] :pong)})}}
           :context {:components {:counter (atom 0)}}}))
 
 ; get a handler
 (k/some-handler d :api/nill)
-(k/some-handler d :api/stateful/inc!)
+(k/some-handler d :api.stateful/inc!)
 
 ; invoke a handler
 (k/invoke d :api.stateful/inc!)

--- a/dev-src/example/client.clj
+++ b/dev-src/example/client.clj
@@ -12,8 +12,8 @@
 (def hello-world
   (k/handler
     {:name "hello-world"
-     :handler (fn [_]
-                "hello world.")}))
+     :handle (fn [_]
+               "hello world.")}))
 
 (hello-world {})
 
@@ -23,8 +23,8 @@
     {:description "this is a handler for echoing data"
      :name :echo
      :summary "echoes data"
-     :handler (fn [{:keys [data]}]
-                data)}))
+     :handle (fn [{:keys [data]}]
+               data)}))
 
 (echo {:data {:name "tommi"}})
 
@@ -34,8 +34,8 @@
     {:description "fnk echo"
      :name :fnkecho
      :summery "echoes data"
-     :handler (p/fnk [[:data x :- s/Int, y :- s/Int]]
-                (+ x y))}))
+     :handle (p/fnk [[:data x :- s/Int, y :- s/Int]]
+               (+ x y))}))
 
 (plus {:data {:x 1, :y 2}})
 
@@ -67,7 +67,7 @@
                                     hello-world]
                            :public (k/handler
                                      {:name :ping
-                                      :handler (p/fnk [] :pong)})}}
+                                      :handle (p/fnk [] :pong)})}}
           :context {:components {:counter (atom 0)}}}))
 
 ; get a handler

--- a/dev-src/example/github/client.clj
+++ b/dev-src/example/github/client.clj
@@ -7,38 +7,38 @@
   (./aprint context)
 
   (./aprint
-    (:body (k/query context :/api/a/b/c/ping)))
+    (:body (k/query context :api.a.b.c/ping)))
 
   (./aprint
-    (:body (k/query context :/api/calculator/plus)))
+    (:body (k/query context :api.calculator/plus)))
 
   (./aprint
-    (:body (k/query context :/api/calculator/plus {:x 1})))
+    (:body (k/query context :api.calculator/plus {:x 1})))
 
   (./aprint
-    (:body (k/query context :/api/calculator/plus {:x 1, :y 2})))
+    (:body (k/query context :api.calculator/plus {:x 1, :y 2})))
 
   (def context2 (k/context context {:x 1}))
 
   (./aprint context2)
 
   (./aprint
-    (:body (k/query context2 :/api/calculator/plus {:y 2})))
+    (:body (k/query context2 :api.calculator/plus {:y 2})))
 
   (def context3 (k/context context2 {:y 2}))
 
   (./aprint
-    (:body (k/query context3 :/api/calculator/plus)))
+    (:body (k/query context3 :api.calculator/plus)))
 
   ;;
   ;; Special thingies
   ;;
 
   (./aprint
-    (:body (k/query context3 :/kekkonen/all)))
+    (:body (k/query context3 :kekkonen/all)))
 
   (./pprint
-    (map (juxt :action :type) (:body (k/query context3 :/kekkonen/get-all))))
+    (map (juxt :action :type) (:body (k/query context3 :kekkonen/get-all))))
 
   (./pprint
-    (map (juxt :action :type) (:body (k/query context3 :/kekkonen/available-handlers)))))
+    (map (juxt :action :type) (:body (k/query context3 :kekkonen/available-handlers)))))

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [ring-middleware-format "0.7.0"]
 
                  ;; client stuff, separate module?
-                 [clj-http "3.0.1"]]
+                 [clj-http "3.1.0"]]
   :profiles {:dev {:plugins [[lein-midje "3.2"]]
                    :source-paths ["dev-src" "src"]
                    :dependencies [[org.clojure/clojure "1.8.0"]

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -172,7 +172,7 @@
 
 (s/defn handler
   ([meta :- KeywordMap]
-    (handler (dissoc meta :handler) (:handler meta)))
+    (handler (dissoc meta :handle) (:handle meta)))
   ([meta :- KeywordMap, f :- Function]
     (assert (:name meta) "handler should have :name")
     (vary-meta f merge {:type :handler} meta)))

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -171,9 +171,11 @@
     :arglists))
 
 (s/defn handler
-  [meta :- KeywordMap, f :- Function]
-  (assert (:name meta) "handler should have :name")
-  (vary-meta f merge {:type :handler} meta))
+  ([meta :- KeywordMap]
+    (handler (dissoc meta :handler) (:handler meta)))
+  ([meta :- KeywordMap, f :- Function]
+    (assert (:name meta) "handler should have :name")
+    (vary-meta f merge {:type :handler} meta)))
 
 (defn handler? [x]
   (and (map? x) (:function x) (:type x)))

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -74,7 +74,7 @@
     {(s/optional-key :data) s/Any}))
 
 (s/defschema Handler
-  {:function Function
+  {:handle Function
    :type s/Keyword
    :name s/Keyword
    :ns (s/maybe s/Keyword)
@@ -178,7 +178,7 @@
     (vary-meta f merge {:type :handler} meta)))
 
 (defn handler? [x]
-  (and (map? x) (:function x) (:type x)))
+  (and (map? x) (:handle x) (:type x)))
 
 ;;
 ;; Namespaces
@@ -204,7 +204,7 @@
         (if name
           {(namespace
              {:name (keyword name)})
-           {:function this
+           {:handle this
             :type type
             :name (keyword name)
             :meta (user-meta meta)
@@ -220,7 +220,7 @@
       (let [{:keys [input output]} (kc/extract-schema this)]
         {(namespace
            {:name (keyword name)})
-         {:function @this
+         {:handle @this
           :type type
           :name (keyword name)
           :meta (user-meta meta)
@@ -394,12 +394,12 @@
 (defn- intercept-handler [mode]
   {:enter
    (fn [context]
-     (let [{:keys [function input output]} (::handler context)
+     (let [{:keys [handle input output]} (::handler context)
            dispatcher (::dispatcher context)
            input-matcher (-> dispatcher :coercion :input)]
        (let [context (if (#{:validate :invoke} mode) (input-coerce! context input input-matcher) context)
              response (if (#{:invoke} mode)
-                        (as-> (function context) response
+                        (as-> (handle context) response
                               (if (and output (-> dispatcher :coercion :output))
                                 (coerce! output (-> dispatcher :coercion :output) response nil ::response)
                                 response)))]

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -204,11 +204,11 @@
                 s/Keyword s/Any}
                s/Keyword s/Any}
        :description "Returns a handler info or nil."
-       :handler (fn [{{{action :kekkonen.action} :query-params} :request :as context}]
-                  (ok (k/public-handler
-                        (k/some-handler
-                          (k/get-dispatcher context)
-                          action))))})
+       :handle (fn [{{{action :kekkonen.action} :query-params} :request :as context}]
+                 (ok (k/public-handler
+                       (k/some-handler
+                         (k/get-dispatcher context)
+                         action))))})
     (k/handler
       {:name "handlers"
        :type ::handler
@@ -221,14 +221,14 @@
                 s/Keyword s/Any}
                s/Keyword s/Any}
        :description "Return a list of available handlers from kekkonen.ns namespace"
-       :handler (fn [{{{ns :kekkonen.ns} :query-params} :request :as context}]
-                  (ok (->> context
-                           k/get-dispatcher
-                           (p/<- (k/available-handlers ns (clean-context context)))
-                           (filter (p/fn-> :ring))
-                           (remove (p/fn-> :ns (= :kekkonen)))
-                           (remove (p/fn-> :meta :no-doc))
-                           (map k/public-handler))))})
+       :handle (fn [{{{ns :kekkonen.ns} :query-params} :request :as context}]
+                 (ok (->> context
+                          k/get-dispatcher
+                          (p/<- (k/available-handlers ns (clean-context context)))
+                          (filter (p/fn-> :ring))
+                          (remove (p/fn-> :ns (= :kekkonen)))
+                          (remove (p/fn-> :meta :no-doc))
+                          (map k/public-handler))))})
     (k/handler
       {:name "actions"
        :type ::handler
@@ -245,12 +245,12 @@
                 s/Keyword s/Any}
                s/Keyword s/Any}
        :description "Return a map of action -> error of all available handlers"
-       :handler (fn [{{{mode :kekkonen.mode ns, :kekkonen.ns} :query-params} :request :as context}]
-                  (ok (->> context
-                           k/get-dispatcher
-                           (p/<- (k/dispatch-handlers (or mode :check) ns (clean-context context)))
-                           (filter (p/fn-> first :ring))
-                           (remove (p/fn-> first :ns (= :kekkonen)))
-                           (remove (p/fn-> first :meta :no-doc))
-                           (map (fn [[k v]] [(:action k) (k/stringify-schema v)]))
-                           (into {}))))})]})
+       :handle (fn [{{{mode :kekkonen.mode ns, :kekkonen.ns} :query-params} :request :as context}]
+                 (ok (->> context
+                          k/get-dispatcher
+                          (p/<- (k/dispatch-handlers (or mode :check) ns (clean-context context)))
+                          (filter (p/fn-> first :ring))
+                          (remove (p/fn-> first :ns (= :kekkonen)))
+                          (remove (p/fn-> first :meta :no-doc))
+                          (map (fn [[k v]] [(:action k) (k/stringify-schema v)]))
+                          (into {}))))})]})

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -203,12 +203,12 @@
                  s/Keyword s/Any}
                 s/Keyword s/Any}
                s/Keyword s/Any}
-       :description "Returns a handler info or nil."}
-      (fn [{{{action :kekkonen.action} :query-params} :request :as context}]
-        (ok (k/public-handler
-              (k/some-handler
-                (k/get-dispatcher context)
-                action)))))
+       :description "Returns a handler info or nil."
+       :handler (fn [{{{action :kekkonen.action} :query-params} :request :as context}]
+                  (ok (k/public-handler
+                        (k/some-handler
+                          (k/get-dispatcher context)
+                          action))))})
     (k/handler
       {:name "handlers"
        :type ::handler
@@ -220,15 +220,15 @@
                  s/Keyword s/Any}
                 s/Keyword s/Any}
                s/Keyword s/Any}
-       :description "Return a list of available handlers from kekkonen.ns namespace"}
-      (fn [{{{ns :kekkonen.ns} :query-params} :request :as context}]
-        (ok (->> context
-                 k/get-dispatcher
-                 (p/<- (k/available-handlers ns (clean-context context)))
-                 (filter (p/fn-> :ring))
-                 (remove (p/fn-> :ns (= :kekkonen)))
-                 (remove (p/fn-> :meta :no-doc))
-                 (map k/public-handler)))))
+       :description "Return a list of available handlers from kekkonen.ns namespace"
+       :handler (fn [{{{ns :kekkonen.ns} :query-params} :request :as context}]
+                  (ok (->> context
+                           k/get-dispatcher
+                           (p/<- (k/available-handlers ns (clean-context context)))
+                           (filter (p/fn-> :ring))
+                           (remove (p/fn-> :ns (= :kekkonen)))
+                           (remove (p/fn-> :meta :no-doc))
+                           (map k/public-handler))))})
     (k/handler
       {:name "actions"
        :type ::handler
@@ -244,13 +244,13 @@
                  s/Keyword s/Any}
                 s/Keyword s/Any}
                s/Keyword s/Any}
-       :description "Return a map of action -> error of all available handlers"}
-      (fn [{{{mode :kekkonen.mode ns, :kekkonen.ns} :query-params} :request :as context}]
-        (ok (->> context
-                 k/get-dispatcher
-                 (p/<- (k/dispatch-handlers (or mode :check) ns (clean-context context)))
-                 (filter (p/fn-> first :ring))
-                 (remove (p/fn-> first :ns (= :kekkonen)))
-                 (remove (p/fn-> first :meta :no-doc))
-                 (map (fn [[k v]] [(:action k) (k/stringify-schema v)]))
-                 (into {})))))]})
+       :description "Return a map of action -> error of all available handlers"
+       :handler (fn [{{{mode :kekkonen.mode ns, :kekkonen.ns} :query-params} :request :as context}]
+                  (ok (->> context
+                           k/get-dispatcher
+                           (p/<- (k/dispatch-handlers (or mode :check) ns (clean-context context)))
+                           (filter (p/fn-> first :ring))
+                           (remove (p/fn-> first :ns (= :kekkonen)))
+                           (remove (p/fn-> first :meta :no-doc))
+                           (map (fn [[k v]] [(:action k) (k/stringify-schema v)]))
+                           (into {}))))})]})

--- a/src/kekkonen/swagger.clj
+++ b/src/kekkonen/swagger.clj
@@ -74,10 +74,10 @@
        :kekkonen.ring/method :get
        :name spec
        :no-doc true
-       :handler (fn [{:keys [request] :as context}]
-                  (let [dispatcher (k/get-dispatcher context)
-                        ns (some-> context :request :query-params :ns str keyword)
-                        handlers (k/available-handlers dispatcher ns (#'r/clean-context context))]
-                    (ok (swagger-object
-                          (add-base-path request (ring-swagger handlers swagger))
-                          (-> options :options :spec)))))})))
+       :handle (fn [{:keys [request] :as context}]
+                 (let [dispatcher (k/get-dispatcher context)
+                       ns (some-> context :request :query-params :ns str keyword)
+                       handlers (k/available-handlers dispatcher ns (#'r/clean-context context))]
+                   (ok (swagger-object
+                         (add-base-path request (ring-swagger handlers swagger))
+                         (-> options :options :spec)))))})))

--- a/src/kekkonen/swagger.clj
+++ b/src/kekkonen/swagger.clj
@@ -73,11 +73,11 @@
       {:type :kekkonen.ring/handler
        :kekkonen.ring/method :get
        :name spec
-       :no-doc true}
-      (fn [{:keys [request] :as context}]
-        (let [dispatcher (k/get-dispatcher context)
-              ns (some-> context :request :query-params :ns str keyword)
-              handlers (k/available-handlers dispatcher ns (#'r/clean-context context))]
-          (ok (swagger-object
-                (add-base-path request (ring-swagger handlers swagger))
-                (-> options :options :spec))))))))
+       :no-doc true
+       :handler (fn [{:keys [request] :as context}]
+                  (let [dispatcher (k/get-dispatcher context)
+                        ns (some-> context :request :query-params :ns str keyword)
+                        handlers (k/available-handlers dispatcher ns (#'r/clean-context context))]
+                    (ok (swagger-object
+                          (add-base-path request (ring-swagger handlers swagger))
+                          (-> options :options :spec)))))})))

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -128,7 +128,7 @@
           k/default-type-resolver) => (just
                                         {(k/namespace {:name :echo})
                                          (just
-                                           {:function fn?
+                                           {:handle fn?
                                             :description ""
                                             :meta {}
                                             :type :handler
@@ -158,7 +158,7 @@
         k/default-type-resolver) => (just
                                       {(k/namespace {:name :echo})
                                        (just
-                                         {:function fn?
+                                         {:handle fn?
                                           :type :handler
                                           :name :echo
                                           :meta {:query true
@@ -184,7 +184,7 @@
         k/default-type-resolver) => (just
                                       {(k/namespace {:name :echo})
                                        (just
-                                         {:function fn?
+                                         {:handle fn?
                                           :type :handler
                                           :name :echo
                                           :meta {}

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -109,6 +109,11 @@
     ((k/type-resolver :kikka) {}) => nil
     ((k/type-resolver :kikka :kukka) {}) => nil))
 
+(fact "handler generation"
+  (let [handler1 (k/handler {:name "kikka"} identity)
+        handler2 (k/handler {:name "kikka" :handler identity})]
+    handler1 => handler2))
+
 (fact "collecting handlers"
   (fact "anonymous functions"
 
@@ -118,8 +123,8 @@
         (k/collect
           (k/handler
             {:name :echo
-             :input {:name s/Str}}
-            identity)
+             :input {:name s/Str}
+             :handler identity})
           k/default-type-resolver) => (just
                                         {(k/namespace {:name :echo})
                                          (just
@@ -135,8 +140,8 @@
         (k/collect
           (k/handler
             {:name :echo
-             :type :kikka}
-            identity)
+             :type :kikka
+             :handler identity})
           k/any-type-resolver) => (just
                                     {(k/namespace {:name :echo})
                                      (contains
@@ -148,8 +153,8 @@
           {:name :echo
            :description "Echoes the user"
            :query true
-           :roles #{:admin :user}}
-          (p/fnk f :- User [data :- User] data))
+           :roles #{:admin :user}
+           :handler (p/fnk f :- User [data :- User] data)})
         k/default-type-resolver) => (just
                                       {(k/namespace {:name :echo})
                                        (just
@@ -166,8 +171,8 @@
     (fact "with unresolved type"
       (let [handler (k/handler
                       {:name :echo
-                       :input {:name s/Str}}
-                      identity)]
+                       :input {:name s/Str}
+                       :handler identity})]
         (k/collect
           handler
           (k/type-resolver :ILLEGAL)) => (throws? {:target handler}))))
@@ -272,8 +277,8 @@
                             :abba [#'ping #'echo]
                             :wasp ['kekkonen.core-test]
                             :bon (k/handler
-                                   {:name :jovi}
-                                   (constantly :runaway))}})]
+                                   {:name :jovi
+                                    :handler (constantly :runaway)})}})]
 
       (fact "deeply nested"
         (fact "namespaces can be joined with ."
@@ -322,8 +327,8 @@
 
 (fact "special keys in context"
   (let [d (k/dispatcher {:handlers {:api (k/handler
-                                           {:name :echo}
-                                           identity)}})]
+                                           {:name :echo
+                                            :handler identity})}})]
     (k/invoke d :api/echo) => (contains
                                 {::k/dispatcher d
                                  ::k/handler (k/some-handler d :api/echo)})))
@@ -348,15 +353,15 @@
                                             {:name :fn-plus
                                              :type ::input-output-schemas
                                              :input {:data {:x s/Int, :y s/Int}}
-                                             :output {:result s/Int}}
-                                            (fn [{{:keys [x y]} :data}]
-                                              {:result (+ x y)}))
+                                             :output {:result s/Int}
+                                             :handler (fn [{{:keys [x y]} :data}]
+                                                        {:result (+ x y)})})
                                           (k/handler
                                             {:name :fnk-plus
-                                             :type ::input-output-schemas}
-                                            (p/fnk f :- {:result s/Int}
-                                              [[:data x :- s/Int, y :- s/Int]]
-                                              {:result (+ x y)}))]}
+                                             :type ::input-output-schemas
+                                             :handler (p/fnk f :- {:result s/Int}
+                                                        [[:data x :- s/Int, y :- s/Int]]
+                                                        {:result (+ x y)})})]}
                          :type-resolver (k/type-resolver ::input-output-schemas)})]
 
     (fact "handlers are registered ok"
@@ -407,7 +412,7 @@
 
   (facts "undefined meta"
     (k/dispatcher
-      {:handlers {:api (k/handler {:kikka :kukka :name :abba} identity)}})
+      {:handlers {:api (k/handler {:kikka :kukka :name :abba :handler identity})}})
     => (throws? {:name :abba, :invalid-keys [:kikka]}))
 
   (let [inc* (fn [value]
@@ -430,8 +435,8 @@
                                    {:name :test
                                     ::inc 2
                                     ::intercept [dec x10]
-                                    ::times 2}
-                                   (p/fn-> :data :x))}
+                                    ::times 2
+                                    :handler (p/fn-> :data :x)})}
                  :meta {::inc inc*
                         ::intercept intercept*
                         ::times times*}})]
@@ -451,8 +456,8 @@
                     {:handlers {:api (k/handler
                                        {:name :test
                                         ::inc 1
-                                        ::times 2}
-                                       (p/fn-> :data :x))}
+                                        ::times 2
+                                        :handler (p/fn-> :data :x)})}
                      :meta [[::inc inc*]
                             [::times times*]]})]
 
@@ -478,8 +483,8 @@
                     {:handlers {:api (k/handler
                                        {:name :test
                                         ::inc 1
-                                        ::times 2}
-                                       (p/fn-> :data :x))}
+                                        ::times 2
+                                        :handler (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -499,8 +504,8 @@
                           ::times 2})
                 d (k/dispatcher
                     {:handlers {api-ns (k/handler
-                                         {:name :test}
-                                         (p/fn-> :data :x))}
+                                         {:name :test
+                                          :handler (p/fn-> :data :x)})}
                      :meta [[::inc inc*]
                             [::times times*]]})]
 
@@ -519,8 +524,8 @@
                           ::times 2})
                 d (k/dispatcher
                     {:handlers {api-ns (k/handler
-                                         {:name :test}
-                                         (p/fn-> :data :x))}
+                                         {:name :test
+                                          :handler (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -541,8 +546,8 @@
                     {:handlers {api-ns (k/handler
                                          {:name :test
                                           ::times 3
-                                          :interceptors [[inc* 100]]}
-                                         (p/fn-> :data :x))}
+                                          :interceptors [[inc* 100]]
+                                          :handler (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -561,8 +566,8 @@
         invalid-input? (contains {:type ::k/request})]
     (let [admin-ns (k/namespace {:name :admin, ::roles! #{:admin}})
           secret-ns (k/namespace {:name :secret, ::roles #{:admin}})
-          handler1 (k/handler {:name :handler1} (p/fnk [] true))
-          handler2 (k/handler {:name :handler2} (p/fnk [[:data x :- s/Bool]] x))
+          handler1 (k/handler {:name :handler1 :handler (p/fnk [] true)})
+          handler2 (k/handler {:name :handler2 :handler (p/fnk [[:data x :- s/Bool]] x)})
           d (k/dispatcher {:meta {::roles! require-role!
                                   ::roles require-role}
                            :handlers {:api {admin-ns [handler1 handler2]
@@ -804,8 +809,8 @@
                       :interceptors [{:enter (->> "7"), :leave (<<- "7")}
                                      {:enter (->> "8"), :leave (<<- "8")}
                                      (->> "9")
-                                     {:leave (<<- "9")}]}
-                     (p/fn-> :x (str "-")))}}
+                                     {:leave (<<- "9")}]
+                      :handler (p/fn-> :x (str "-"))})}}
                  :interceptors [{:enter (->> "1"), :leave (<<- "1")}
                                 {:enter (->> "2"), :leave (<<- "2")}
                                 (->> "3")
@@ -815,7 +820,7 @@
 
     (fact "returning nil on :enter stops the execution"
       (let [d (k/dispatcher
-                {:handlers {:api (k/handler {:name :test} (p/fn-> :x))}
+                {:handlers {:api (k/handler {:name :test :handler (p/fn-> :x)})}
                  :interceptors [(constantly nil)
                                 #(throw AssertionError)]})]
 
@@ -823,7 +828,7 @@
 
     (fact "returning nil on :leave stops the execution"
       (let [d (k/dispatcher
-                {:handlers {:api (k/handler {:name :test} (p/fn-> :x))}
+                {:handlers {:api (k/handler {:name :test :handler (p/fn-> :x)})}
                  :interceptors [{:leave #(throw AssertionError)}
                                 {:leave (constantly nil)}]})]
 
@@ -832,7 +837,7 @@
 (fact "transforming handlers"
   (fact "enriching handlers"
     (k/transform-handlers
-      (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+      (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
       (fn [handler]
         (assoc handler :kikka :kukka)))
 
@@ -845,7 +850,7 @@
 
   (fact "stripping handlers"
     (k/transform-handlers
-      (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+      (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
       (constantly nil))
 
     => (contains
@@ -858,16 +863,19 @@
                      (assoc-in ctx [:entity :doc] (-> ctx :docs (get doc-id)))))
         secret-ns (k/namespace {:name :secret, ::roles #{:admin}})
         doc-ns (k/namespace {:name :doc ::load-doc true})
-        read (k/handler {:name :read} (p/fnk [[:entity doc :- s/Str] :as ctx]
-                                        ;; despite we haven't defined [:data :doc-id], it already coerced!
-                                        (assert (-> ctx :data :doc-id class (= Long)))
-                                        {:read doc}))
-        d (k/dispatcher {:meta {::roles require-role
-                                ::load-doc load-doc}
-                         :coercion {:input {:data str->int-matcher}}
-                         :context {:docs {1 "hello ruby"
-                                          2 "land of lisp"}}
-                         :handlers {:api {secret-ns {doc-ns read}}}})]
+        read (k/handler
+               {:name :read
+                :handler (p/fnk [[:entity doc :- s/Str] :as ctx]
+                           ;; despite we haven't defined [:data :doc-id], it already coerced!
+                           (assert (-> ctx :data :doc-id class (= Long)))
+                           {:read doc})})
+        d (k/dispatcher
+            {:meta {::roles require-role
+                    ::load-doc load-doc}
+             :coercion {:input {:data str->int-matcher}}
+             :context {:docs {1 "hello ruby"
+                              2 "land of lisp"}}
+             :handlers {:api {secret-ns {doc-ns read}}}})]
 
     (fact "input schemas have been modified"
       (let [handler (k/some-handler d :api.secret.doc/read)]
@@ -926,20 +934,20 @@
   (let [d (k/dispatcher {:handlers
                          {:api
                           [(k/handler
-                             {:name :dispatcher}
-                             (partial k/get-dispatcher))
+                             {:name :dispatcher
+                              :handler (partial k/get-dispatcher)})
                            (k/handler
                              {:name :handler
-                              :description "metameta"}
-                             (partial k/get-handler))
+                              :description "metameta"
+                              :handler (partial k/get-handler)})
                            (k/handler
-                             {:name :names}
-                             (fn [context]
-                               (->> context
-                                    k/get-dispatcher
-                                    (p/<- (k/all-handlers nil))
-                                    (map :name)
-                                    set)))]}})]
+                             {:name :names
+                              :handler (fn [context]
+                                         (->> context
+                                              k/get-dispatcher
+                                              (p/<- (k/all-handlers nil))
+                                              (map :name)
+                                              set))})]}})]
 
     (fact "::dispatcher"
       (s/validate Dispatcher (k/invoke d :api/dispatcher)) => (partial instance? Dispatcher))
@@ -953,8 +961,8 @@
 (fact "injecting handlers"
 
   (fact "handlers can be injected"
-    (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
-                (k/inject (k/handler {:name :ping} identity)))]
+    (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
+                (k/inject (k/handler {:name :ping, :handler identity})))]
       d => (contains
              {:handlers
               (just
@@ -962,16 +970,16 @@
                  :ping anything})})))
 
   (fact "injecting nil handlers fails"
-    (-> (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+    (-> (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
         (k/inject nil)) => schema-error?))
 
 (facts "coercion-matcher"
   (let [PositiveInt (s/both s/Int (s/pred pos? 'positive))
         handlers {:api [(k/handler
-                          {:name :plus}
-                          (p/fnk ^:never-validate plus :- {:result PositiveInt}
-                            [[:data x :- s/Int, y :- PositiveInt]]
-                            {:result (+ x y)}))]}]
+                          {:name :plus
+                           :handler (p/fnk ^:never-validate plus :- {:result PositiveInt}
+                                      [[:data x :- s/Int, y :- PositiveInt]]
+                                      {:result (+ x y)})})]}]
 
     (facts "with default settings"
       (let [d (k/dispatcher {:handlers handlers})]
@@ -1022,10 +1030,10 @@
 
       (facts "with input coercion for another key"
         (let [d (k/dispatcher {:handlers {:api [(k/handler
-                                                  {:name :plus}
-                                                  (p/fnk plus [[:data x :- s/Int]
-                                                               [:tada y :- s/Int]]
-                                                    {:result (+ x y)}))]}
+                                                  {:name :plus
+                                                   :handler (p/fnk plus [[:data x :- s/Int]
+                                                                         [:tada y :- s/Int]]
+                                                              {:result (+ x y)})})]}
                                :coercion {:input {:data (constantly nil)
                                                   :tada (constantly nil)}}})]
 
@@ -1050,11 +1058,11 @@
         multi-coercion (k/multi-coercion {:data str->long-coercion})
         handler (k/handler
                   {:name :test
-                   :output {:value s/Int}}
-                  (fn [context]
-                    (:data (k/input-coerce! context {:data {:value s/Int
-                                                            s/Keyword s/Any}
-                                                     s/Keyword s/Any}))))]
+                   :output {:value s/Int}
+                   :handler (fn [context]
+                              (:data (k/input-coerce! context {:data {:value s/Int
+                                                                      s/Keyword s/Any}
+                                                               s/Keyword s/Any})))})]
 
     (facts "manual coercion"
       (facts "with input coercion on"
@@ -1086,10 +1094,10 @@
 
     (fact "automatic endpoint coercion"
       (let [d (k/dispatcher {:handlers {:api (k/handler
-                                               {:name :test}
-                                               (p/fnk ^:never-validate f :- {:value s/Int}
-                                                 [data :- {:value s/Int}]
-                                                 data))}
+                                               {:name :test
+                                                :handler (p/fnk ^:never-validate f :- {:value s/Int}
+                                                           [data :- {:value s/Int}]
+                                                           data)})}
                              :coercion {:input nil}})]
 
         (fact "with request-coercion off"
@@ -1119,11 +1127,11 @@
                              :coercion {:input nil}
                              :handlers {api [(k/handler
                                                {:name :test
-                                                :output {:value s/Int}}
-                                               (fn [context] (:data context)))
+                                                :output {:value s/Int}
+                                                :handler (fn [context] (:data context))})
                                              (k/handler
-                                               {:name :test2}
-                                               (p/fnk [[:data x :- s/Str :as data]] data))]}})]
+                                               {:name :test2
+                                                :handler (p/fnk [[:data x :- s/Str :as data]] data)})]}})]
 
         (pr-str (:input (k/some-handler d :api/test2)))
 

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -111,7 +111,7 @@
 
 (fact "handler generation"
   (let [handler1 (k/handler {:name "kikka"} identity)
-        handler2 (k/handler {:name "kikka" :handler identity})]
+        handler2 (k/handler {:name "kikka" :handle identity})]
     handler1 => handler2))
 
 (fact "collecting handlers"
@@ -124,7 +124,7 @@
           (k/handler
             {:name :echo
              :input {:name s/Str}
-             :handler identity})
+             :handle identity})
           k/default-type-resolver) => (just
                                         {(k/namespace {:name :echo})
                                          (just
@@ -141,7 +141,7 @@
           (k/handler
             {:name :echo
              :type :kikka
-             :handler identity})
+             :handle identity})
           k/any-type-resolver) => (just
                                     {(k/namespace {:name :echo})
                                      (contains
@@ -154,7 +154,7 @@
            :description "Echoes the user"
            :query true
            :roles #{:admin :user}
-           :handler (p/fnk f :- User [data :- User] data)})
+           :handle (p/fnk f :- User [data :- User] data)})
         k/default-type-resolver) => (just
                                       {(k/namespace {:name :echo})
                                        (just
@@ -172,7 +172,7 @@
       (let [handler (k/handler
                       {:name :echo
                        :input {:name s/Str}
-                       :handler identity})]
+                       :handle identity})]
         (k/collect
           handler
           (k/type-resolver :ILLEGAL)) => (throws? {:target handler}))))
@@ -278,7 +278,7 @@
                             :wasp ['kekkonen.core-test]
                             :bon (k/handler
                                    {:name :jovi
-                                    :handler (constantly :runaway)})}})]
+                                    :handle (constantly :runaway)})}})]
 
       (fact "deeply nested"
         (fact "namespaces can be joined with ."
@@ -328,7 +328,7 @@
 (fact "special keys in context"
   (let [d (k/dispatcher {:handlers {:api (k/handler
                                            {:name :echo
-                                            :handler identity})}})]
+                                            :handle identity})}})]
     (k/invoke d :api/echo) => (contains
                                 {::k/dispatcher d
                                  ::k/handler (k/some-handler d :api/echo)})))
@@ -354,14 +354,14 @@
                                              :type ::input-output-schemas
                                              :input {:data {:x s/Int, :y s/Int}}
                                              :output {:result s/Int}
-                                             :handler (fn [{{:keys [x y]} :data}]
-                                                        {:result (+ x y)})})
+                                             :handle (fn [{{:keys [x y]} :data}]
+                                                       {:result (+ x y)})})
                                           (k/handler
                                             {:name :fnk-plus
                                              :type ::input-output-schemas
-                                             :handler (p/fnk f :- {:result s/Int}
-                                                        [[:data x :- s/Int, y :- s/Int]]
-                                                        {:result (+ x y)})})]}
+                                             :handle (p/fnk f :- {:result s/Int}
+                                                       [[:data x :- s/Int, y :- s/Int]]
+                                                       {:result (+ x y)})})]}
                          :type-resolver (k/type-resolver ::input-output-schemas)})]
 
     (fact "handlers are registered ok"
@@ -412,7 +412,7 @@
 
   (facts "undefined meta"
     (k/dispatcher
-      {:handlers {:api (k/handler {:kikka :kukka :name :abba :handler identity})}})
+      {:handlers {:api (k/handler {:kikka :kukka :name :abba :handle identity})}})
     => (throws? {:name :abba, :invalid-keys [:kikka]}))
 
   (let [inc* (fn [value]
@@ -436,7 +436,7 @@
                                     ::inc 2
                                     ::intercept [dec x10]
                                     ::times 2
-                                    :handler (p/fn-> :data :x)})}
+                                    :handle (p/fn-> :data :x)})}
                  :meta {::inc inc*
                         ::intercept intercept*
                         ::times times*}})]
@@ -457,7 +457,7 @@
                                        {:name :test
                                         ::inc 1
                                         ::times 2
-                                        :handler (p/fn-> :data :x)})}
+                                        :handle (p/fn-> :data :x)})}
                      :meta [[::inc inc*]
                             [::times times*]]})]
 
@@ -484,7 +484,7 @@
                                        {:name :test
                                         ::inc 1
                                         ::times 2
-                                        :handler (p/fn-> :data :x)})}
+                                        :handle (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -505,7 +505,7 @@
                 d (k/dispatcher
                     {:handlers {api-ns (k/handler
                                          {:name :test
-                                          :handler (p/fn-> :data :x)})}
+                                          :handle (p/fn-> :data :x)})}
                      :meta [[::inc inc*]
                             [::times times*]]})]
 
@@ -525,7 +525,7 @@
                 d (k/dispatcher
                     {:handlers {api-ns (k/handler
                                          {:name :test
-                                          :handler (p/fn-> :data :x)})}
+                                          :handle (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -547,7 +547,7 @@
                                          {:name :test
                                           ::times 3
                                           :interceptors [[inc* 100]]
-                                          :handler (p/fn-> :data :x)})}
+                                          :handle (p/fn-> :data :x)})}
                      :meta [[::times times*]
                             [::inc inc*]]})]
 
@@ -566,8 +566,8 @@
         invalid-input? (contains {:type ::k/request})]
     (let [admin-ns (k/namespace {:name :admin, ::roles! #{:admin}})
           secret-ns (k/namespace {:name :secret, ::roles #{:admin}})
-          handler1 (k/handler {:name :handler1 :handler (p/fnk [] true)})
-          handler2 (k/handler {:name :handler2 :handler (p/fnk [[:data x :- s/Bool]] x)})
+          handler1 (k/handler {:name :handler1 :handle (p/fnk [] true)})
+          handler2 (k/handler {:name :handler2 :handle (p/fnk [[:data x :- s/Bool]] x)})
           d (k/dispatcher {:meta {::roles! require-role!
                                   ::roles require-role}
                            :handlers {:api {admin-ns [handler1 handler2]
@@ -810,7 +810,7 @@
                                      {:enter (->> "8"), :leave (<<- "8")}
                                      (->> "9")
                                      {:leave (<<- "9")}]
-                      :handler (p/fn-> :x (str "-"))})}}
+                      :handle (p/fn-> :x (str "-"))})}}
                  :interceptors [{:enter (->> "1"), :leave (<<- "1")}
                                 {:enter (->> "2"), :leave (<<- "2")}
                                 (->> "3")
@@ -820,7 +820,7 @@
 
     (fact "returning nil on :enter stops the execution"
       (let [d (k/dispatcher
-                {:handlers {:api (k/handler {:name :test :handler (p/fn-> :x)})}
+                {:handlers {:api (k/handler {:name :test :handle (p/fn-> :x)})}
                  :interceptors [(constantly nil)
                                 #(throw AssertionError)]})]
 
@@ -828,7 +828,7 @@
 
     (fact "returning nil on :leave stops the execution"
       (let [d (k/dispatcher
-                {:handlers {:api (k/handler {:name :test :handler (p/fn-> :x)})}
+                {:handlers {:api (k/handler {:name :test :handle (p/fn-> :x)})}
                  :interceptors [{:leave #(throw AssertionError)}
                                 {:leave (constantly nil)}]})]
 
@@ -837,7 +837,7 @@
 (fact "transforming handlers"
   (fact "enriching handlers"
     (k/transform-handlers
-      (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
+      (k/dispatcher {:handlers {:api (k/handler {:name :test :handle identity})}})
       (fn [handler]
         (assoc handler :kikka :kukka)))
 
@@ -850,7 +850,7 @@
 
   (fact "stripping handlers"
     (k/transform-handlers
-      (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
+      (k/dispatcher {:handlers {:api (k/handler {:name :test :handle identity})}})
       (constantly nil))
 
     => (contains
@@ -865,10 +865,10 @@
         doc-ns (k/namespace {:name :doc ::load-doc true})
         read (k/handler
                {:name :read
-                :handler (p/fnk [[:entity doc :- s/Str] :as ctx]
-                           ;; despite we haven't defined [:data :doc-id], it already coerced!
-                           (assert (-> ctx :data :doc-id class (= Long)))
-                           {:read doc})})
+                :handle (p/fnk [[:entity doc :- s/Str] :as ctx]
+                          ;; despite we haven't defined [:data :doc-id], it already coerced!
+                          (assert (-> ctx :data :doc-id class (= Long)))
+                          {:read doc})})
         d (k/dispatcher
             {:meta {::roles require-role
                     ::load-doc load-doc}
@@ -935,19 +935,19 @@
                          {:api
                           [(k/handler
                              {:name :dispatcher
-                              :handler (partial k/get-dispatcher)})
+                              :handle (partial k/get-dispatcher)})
                            (k/handler
                              {:name :handler
                               :description "metameta"
-                              :handler (partial k/get-handler)})
+                              :handle (partial k/get-handler)})
                            (k/handler
                              {:name :names
-                              :handler (fn [context]
-                                         (->> context
-                                              k/get-dispatcher
-                                              (p/<- (k/all-handlers nil))
-                                              (map :name)
-                                              set))})]}})]
+                              :handle (fn [context]
+                                        (->> context
+                                             k/get-dispatcher
+                                             (p/<- (k/all-handlers nil))
+                                             (map :name)
+                                             set))})]}})]
 
     (fact "::dispatcher"
       (s/validate Dispatcher (k/invoke d :api/dispatcher)) => (partial instance? Dispatcher))
@@ -961,8 +961,8 @@
 (fact "injecting handlers"
 
   (fact "handlers can be injected"
-    (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test :handler identity})}})
-                (k/inject (k/handler {:name :ping, :handler identity})))]
+    (let [d (-> (k/dispatcher {:handlers {:api (k/handler {:name :test :handle identity})}})
+                (k/inject (k/handler {:name :ping, :handle identity})))]
       d => (contains
              {:handlers
               (just
@@ -970,16 +970,16 @@
                  :ping anything})})))
 
   (fact "injecting nil handlers fails"
-    (-> (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
+    (-> (k/dispatcher {:handlers {:api (k/handler {:name :test, :handle identity})}})
         (k/inject nil)) => schema-error?))
 
 (facts "coercion-matcher"
   (let [PositiveInt (s/both s/Int (s/pred pos? 'positive))
         handlers {:api [(k/handler
                           {:name :plus
-                           :handler (p/fnk ^:never-validate plus :- {:result PositiveInt}
-                                      [[:data x :- s/Int, y :- PositiveInt]]
-                                      {:result (+ x y)})})]}]
+                           :handle (p/fnk ^:never-validate plus :- {:result PositiveInt}
+                                     [[:data x :- s/Int, y :- PositiveInt]]
+                                     {:result (+ x y)})})]}]
 
     (facts "with default settings"
       (let [d (k/dispatcher {:handlers handlers})]
@@ -1031,9 +1031,9 @@
       (facts "with input coercion for another key"
         (let [d (k/dispatcher {:handlers {:api [(k/handler
                                                   {:name :plus
-                                                   :handler (p/fnk plus [[:data x :- s/Int]
-                                                                         [:tada y :- s/Int]]
-                                                              {:result (+ x y)})})]}
+                                                   :handle (p/fnk plus [[:data x :- s/Int]
+                                                                        [:tada y :- s/Int]]
+                                                             {:result (+ x y)})})]}
                                :coercion {:input {:data (constantly nil)
                                                   :tada (constantly nil)}}})]
 
@@ -1059,10 +1059,10 @@
         handler (k/handler
                   {:name :test
                    :output {:value s/Int}
-                   :handler (fn [context]
-                              (:data (k/input-coerce! context {:data {:value s/Int
-                                                                      s/Keyword s/Any}
-                                                               s/Keyword s/Any})))})]
+                   :handle (fn [context]
+                             (:data (k/input-coerce! context {:data {:value s/Int
+                                                                     s/Keyword s/Any}
+                                                              s/Keyword s/Any})))})]
 
     (facts "manual coercion"
       (facts "with input coercion on"
@@ -1095,9 +1095,9 @@
     (fact "automatic endpoint coercion"
       (let [d (k/dispatcher {:handlers {:api (k/handler
                                                {:name :test
-                                                :handler (p/fnk ^:never-validate f :- {:value s/Int}
-                                                           [data :- {:value s/Int}]
-                                                           data)})}
+                                                :handle (p/fnk ^:never-validate f :- {:value s/Int}
+                                                          [data :- {:value s/Int}]
+                                                          data)})}
                              :coercion {:input nil}})]
 
         (fact "with request-coercion off"
@@ -1128,10 +1128,10 @@
                              :handlers {api [(k/handler
                                                {:name :test
                                                 :output {:value s/Int}
-                                                :handler (fn [context] (:data context))})
+                                                :handle (fn [context] (:data context))})
                                              (k/handler
                                                {:name :test2
-                                                :handler (p/fnk [[:data x :- s/Str :as data]] data)})]}})]
+                                                :handle (p/fnk [[:data x :- s/Str :as data]] data)})]}})]
 
         (pr-str (:input (k/some-handler d :api/test2)))
 
@@ -1154,3 +1154,8 @@
 
 (fact "printing it"
   (pr-str (k/dispatcher {:handlers {}})) => "#<Dispatcher>")
+
+
+(def dispatcher
+  (k/dispatcher
+    {:handlers {:api (k/handler {:name :hello, :handle (constantly "hello world")})}}))

--- a/test/kekkonen/ring_test.clj
+++ b/test/kekkonen/ring_test.clj
@@ -184,9 +184,9 @@
     (fact "if handler is dependent on :data-input, default coercion is applies"
       (let [app (r/ring-handler
                   (k/dispatcher {:handlers {:api (k/handler
-                                                   {:name :plus}
-                                                   (p/fnk [[:data x :- s/Int, y :- s/Int]]
-                                                     (ok (+ x y))))}})
+                                                   {:name :plus
+                                                    :handler (p/fnk [[:data x :- s/Int, y :- s/Int]]
+                                                               (ok (+ x y)))})}})
                   {:coercion {:body-params nil}})]
 
         (app {:uri "/api/plus"
@@ -214,7 +214,7 @@
 (facts "mapping"
   (facts "default body-params -> data"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}}))]
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}}))]
 
       (app {:uri "/api/test"
             :request-method :post
@@ -222,7 +222,7 @@
 
   (fact "custom query-params -> query via interceptor"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
                 {:interceptors [(k/context-copy [:request :query-params] [:query])]})]
 
       (app {:uri "/api/test"
@@ -231,7 +231,7 @@
 
   (fact "custom query-params -> query via parameters"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test} identity)}})
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
                 {:types {:handler {:parameters {[:query] [:request :query-params]}}}})]
 
       (app {:uri "/api/test"
@@ -253,8 +253,8 @@
                 {:handlers
                  {:api
                   (k/handler
-                    {:name :test}
-                    (partial k/get-handler))}}))]
+                    {:name :test
+                     :handler (partial k/get-handler)})}}))]
 
     (app {:uri "/api/test" :request-method :post}) => (contains
                                                         {:ring
@@ -269,9 +269,9 @@
                 {:handlers
                  {:api
                   (k/handler
-                    {:name :test}
-                    (fn [context]
-                      {:user (-> context ::user)}))}})
+                    {:name :test
+                     :handler (fn [context]
+                                {:user (-> context ::user)})})}})
               {:interceptors [{:enter (fn [ctx]
                                         (let [user (get-in ctx [:request :header-params "user"])]
                                           (assoc ctx ::user user)))
@@ -295,6 +295,6 @@
   (let [app (r/ring-handler
               (k/dispatcher
                 {:context {:secret 42}
-                 :handlers {:api (k/handler {:name :ipa} (fn [ctx] (::value ctx)))}})
+                 :handlers {:api (k/handler {:name :ipa, :handler (fn [ctx] (::value ctx))})}})
               {:interceptors [(fn [ctx] (assoc ctx ::value (:secret ctx)))]})]
     (app {:uri "/api/ipa" :request-method :post}) => 42))

--- a/test/kekkonen/ring_test.clj
+++ b/test/kekkonen/ring_test.clj
@@ -185,8 +185,8 @@
       (let [app (r/ring-handler
                   (k/dispatcher {:handlers {:api (k/handler
                                                    {:name :plus
-                                                    :handler (p/fnk [[:data x :- s/Int, y :- s/Int]]
-                                                               (ok (+ x y)))})}})
+                                                    :handle (p/fnk [[:data x :- s/Int, y :- s/Int]]
+                                                              (ok (+ x y)))})}})
                   {:coercion {:body-params nil}})]
 
         (app {:uri "/api/plus"
@@ -214,7 +214,7 @@
 (facts "mapping"
   (facts "default body-params -> data"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}}))]
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handle identity})}}))]
 
       (app {:uri "/api/test"
             :request-method :post
@@ -222,7 +222,7 @@
 
   (fact "custom query-params -> query via interceptor"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handle identity})}})
                 {:interceptors [(k/context-copy [:request :query-params] [:query])]})]
 
       (app {:uri "/api/test"
@@ -231,7 +231,7 @@
 
   (fact "custom query-params -> query via parameters"
     (let [app (r/ring-handler
-                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handler identity})}})
+                (k/dispatcher {:handlers {:api (k/handler {:name :test, :handle identity})}})
                 {:types {:handler {:parameters {[:query] [:request :query-params]}}}})]
 
       (app {:uri "/api/test"
@@ -254,7 +254,7 @@
                  {:api
                   (k/handler
                     {:name :test
-                     :handler (partial k/get-handler)})}}))]
+                     :handle (partial k/get-handler)})}}))]
 
     (app {:uri "/api/test" :request-method :post}) => (contains
                                                         {:ring
@@ -270,8 +270,8 @@
                  {:api
                   (k/handler
                     {:name :test
-                     :handler (fn [context]
-                                {:user (-> context ::user)})})}})
+                     :handle (fn [context]
+                               {:user (-> context ::user)})})}})
               {:interceptors [{:enter (fn [ctx]
                                         (let [user (get-in ctx [:request :header-params "user"])]
                                           (assoc ctx ::user user)))
@@ -295,6 +295,6 @@
   (let [app (r/ring-handler
               (k/dispatcher
                 {:context {:secret 42}
-                 :handlers {:api (k/handler {:name :ipa, :handler (fn [ctx] (::value ctx))})}})
+                 :handlers {:api (k/handler {:name :ipa, :handle (fn [ctx] (::value ctx))})}})
               {:interceptors [(fn [ctx] (assoc ctx ::value (:secret ctx)))]})]
     (app {:uri "/api/ipa" :request-method :post}) => 42))


### PR DESCRIPTION
* **BREAKING**: Handler dispatch function is now `:handle` instead of `:function`
* Handlers can be defined via a single map with `:handle` key for the dispatch

```clj
(k/handler
  {:name "hello"
   :handle (constantly "hello")})
```