### PR TITLE
Handle vector inputs with apis, fixes #27

### DIFF
--- a/src/kekkonen/common.clj
+++ b/src/kekkonen/common.clj
@@ -24,21 +24,22 @@
 ;; Deep Merge: fast
 ;;
 
-(defn- deep-merge* [& maps]
+(defn- deep-merge* [& colls]
   (let [f (fn [old new]
             (if (and (map? old) (map? new))
               (merge-with deep-merge* old new)
               new))]
-    (if (every? map? maps)
-      (apply merge-with f maps)
-      (last maps))))
+    (if (every? map? colls)
+      (apply merge-with f colls)
+      (last colls))))
 
 (defn deep-merge
-  "Deep-merges map together, non-maps are overridden"
-  [& maps]
-  (let [maps (filter identity maps)]
-    (assert (every? map? maps))
-    (apply merge-with deep-merge* maps)))
+  "Deep-merges things together"
+  [& coll]
+  (let [values (filter identity coll)]
+    (if (every? map? values)
+      (apply merge-with deep-merge* values)
+      (last values))))
 
 ;;
 ;; Deep Merge: slower, merges all map-like forms

--- a/test/kekkonen/api_test.clj
+++ b/test/kekkonen/api_test.clj
@@ -324,3 +324,14 @@
     (api {:core {:handlers {secret-ns [#'nada]}, :meta [[::role require-role]]}}))
   (fact "invalid meta causes creation-time exception"
     (api {:core {:handlers {secret-ns [#'nada]}, :meta {}}}) => (throws? {:name :nada, :invalid-keys [::role]})))
+
+(fact "vector schemas, #27"
+  (let [app (api {:core {:handlers {:api (k/handler
+                                           {:name :vectorz
+                                            :handle (p/fnk [data :- [{:kikka s/Str}]]
+                                                      (ok data))})}}})]
+    (let [response (app {:uri "/api/vectorz"
+                         :request-method :post
+                         :body-params [{:kikka "kukka"}, {:kikka "kakka"}]})]
+      response => ok?
+      (parse response) => [{:kikka "kukka"}, {:kikka "kakka"}])))

--- a/test/kekkonen/common_test.clj
+++ b/test/kekkonen/common_test.clj
@@ -35,7 +35,12 @@
   (kc/deep-merge-from-to
     {:data {:x String} :request {:body-params {:y String}}}
     [[:data] [:request :body-params]])
-  => {:data {:x String} :request {:body-params {:x String, :y String}}})
+  => {:data {:x String} :request {:body-params {:x String, :y String}}}
+  (fact "with non maps, data is overridden, #27"
+    (kc/deep-merge-from-to
+      {:data {:x String} :request {:body-params [{:y String}]}}
+      [[:data] [:request :body-params]])
+    => {:data {:x String} :request {:body-params {:x String}}}))
 
 (fact "deep-merge-to-from"
   (kc/deep-merge-to-from
@@ -92,5 +97,6 @@
 (p/defnk handler [[:data x :- s/Int] y :- s/Bool])
 
 (fact "extracting schemas"
-  (kc/extract-schema handler) => {:input {:data {:x s/Int, s/Keyword s/Any}, :y s/Bool, s/Keyword s/Any}
+  (kc/extract-schema handler) => {:input {:data {:x s/Int, s/Keyword s/Any}
+                                          :y s/Bool, s/Keyword s/Any}
                                   :output s/Any})

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -1154,3 +1154,11 @@
 
 (fact "printing it"
   (pr-str (k/dispatcher {:handlers {}})) => "#<Dispatcher>")
+
+(fact "vector schemas, #27"
+  (let [d (k/dispatcher {:handlers {:api (k/handler
+                                           {:name :vector
+                                            :handle (p/fnk [data :- [{:kikka s/Str}]]
+                                                      data)})}})]
+    (k/invoke d :api/vector {:data [{:kikka "kukka"}, {:kikka "kakka"}]})
+    => [{:kikka "kukka"}, {:kikka "kakka"}]))


### PR DESCRIPTION
`kekkonen.common/deep-merge` was not asserting that only maps are allowed. Instead - for non-maps, we take the last form. Added (regression) tests form common, core & api.