### PR TITLE
Pedestal-style interceptors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## 0.3.0-SNAPSHOT
 
 * **BREAKING**: Removed type-level interceptors from ring-adapter, use normal interceptors instead.
+* **BREAKING**: Ring request-parameters are now assoc-in'd (into `:data`) instead of deep-merging. For speed.
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
 * Data input schemas for apis can be vectors, fixes [#27](https://github.com/metosin/kekkonen/issues/27).
 * Use Pedestal-style interceptors, with `:name`, `:enter`, `:leave` and `:error`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,20 @@
 ## 0.3.0-SNAPSHOT
 
-* **BREAKING**: Removed type-level interceptors from ring-adapter.
+* **BREAKING**: Removed type-level interceptors from ring-adapter, use normal interceptors instead.
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
 * Data input schemas for apis can be vectors, fixes [#27](https://github.com/metosin/kekkonen/issues/27).
+* Use Pedestal-style interceptors, with `:name`, `:enter`, `:leave` and `:error`
+  * Extended to contain `:input` and `:output` schemas.
+* Interceptors are pre-compiled for better perf.
+* Interceptors can be `nil`, allowing conditional interceptors
+
+```clj
+(k/handler
+  {:name "fixture!"
+   :interceptors [[require-role :admin] (if-not env/dev-mode? log-it)]
+   :handle (fn [ctx] ...)})
+```
+
 * **BREAKING**: top-level swagger options are now in align to the compojure-api:
   * Fixes [#22](https://github.com/metosin/kekkonen/issues/22)
   * By default, `api`s don't bind swagger-spec & swagger-ui, use `:spec` & `:ui` options

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 * **BREAKING**: Removed type-level interceptors from ring-adapter, use normal interceptors instead.
 * **BREAKING**: Ring request-parameters are now assoc-in'd (into `:data`) instead of deep-merging. For speed.
+* Handlers can be now be mounted to dispatcher root
 * Support for Context-based urls, thanks to [Wout Neirynck](https://github.com/wneirynck).
 * Data input schemas for apis can be vectors, fixes [#27](https://github.com/metosin/kekkonen/issues/27).
 * Use Pedestal-style interceptors, with `:name`, `:enter`, `:leave` and `:error`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,10 @@
 * Data input schemas for apis can be vectors, fixes [#27](https://github.com/metosin/kekkonen/issues/27).
 * Use Pedestal-style interceptors, with `:name`, `:enter`, `:leave` and `:error`
   * Extended to contain `:input` and `:output` schemas.
-* Interceptors are pre-compiled for better perf.
+* Interceptors are pre-compiled in all layers for simplicity and better perf.
+* Remove the following excess meta-data from handlers: 
+  * `:ns-meta`, `:all-meta`, `:handler-input` & `:user-input`
+* Remove `:interceptors` from the `Dispatcher`, as they are now precompiled into handlers
 * Interceptors can be `nil`, allowing conditional interceptors
 
 ```clj

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,7 +57,7 @@
 [prismatic/plumbing "0.5.3"] is available but we use "0.5.2"
 [metosin/ring-http-response "0.7.0"] is available but we use "0.6.5"
 [metosin/ring-swagger "0.22.9"] is available but we use "0.22.6"
-[clj-http "3.1.0"] available but we use "2.1.0"
+[clj-http "2.2.0"] available but we use "2.1.0"
 ```
 
 ## 0.2.0 (29.3.2016)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,9 +37,10 @@
 * updated dependencies:
 
 ```clj
-[prismatic/schema "1.1.1"] is available but we use "1.1.0"
+[prismatic/schema "1.1.2"] is available but we use "1.1.0"
 [prismatic/plumbing "0.5.3"] is available but we use "0.5.2"
-[metosin/ring-swagger "0.22.8"] is available but we use "0.22.6"
+[metosin/ring-http-response "0.7.0"] is available but we use "0.6.5"
+[metosin/ring-swagger "0.22.9"] is available but we use "0.22.6"
 [clj-http "3.1.0"] available but we use "2.1.0"
 ```
 

--- a/dev-src/example/kebab.clj
+++ b/dev-src/example/kebab.clj
@@ -110,7 +110,10 @@
 
 (def app
   (cqrs-api
-    {:core {:handlers {:kebab [#'get-kebabs #'add-kebab #'reset-kebabs]
+    {:swagger {:ui "/api-docs"
+               :spec "/swagger.json"
+               :data {:info {:title "Kebab Api"}}}
+     :core {:handlers {:kebab [#'get-kebabs #'add-kebab #'reset-kebabs]
                        :math 'example.math
                        :tx [#'transact #'speculative]}
             :context {:db (atom {})

--- a/examples/hello-world/src/sample/handler.clj
+++ b/examples/hello-world/src/sample/handler.clj
@@ -6,7 +6,7 @@
 (defnk ^:query hello [[:data name :- String]]
   (success {:message (str "Hello, " name)}))
 
-(def app (cqrs-api {:core {:handlers {:api #'hello}}}))
+(def app (cqrs-api {:core {:handlers #'hello}}))
 
 (defn start []
   (server/run-server #'app {:port 3000}))
@@ -17,10 +17,9 @@
 ;   (server/run-server
 ;    (cqrs-api
 ;      {:core
-;        {:handlers
-;          {:api
-;            (query
-;              {:name "hello"
-;               :handle (fn [{{:keys [name]} :data}]
-;                         (success {:message (str "Hello, " name)}))})}}})
+;       {:handlers
+;        (query
+;          {:name "hello"
+;           :handle (fn [{{:keys [name]} :data}]
+;                     (success {:message (str "Hello, " name)}))})}})
 ;    {:port 3000}))

--- a/examples/hello-world/src/sample/handler.clj
+++ b/examples/hello-world/src/sample/handler.clj
@@ -3,30 +3,24 @@
             [plumbing.core :refer [defnk]]
             [kekkonen.cqrs :refer :all]))
 
-(defnk ^:query hello-world
-  "says hallo"
-  {:responses {:default {:schema {:message String}}}}
-  [[:data name :- String]]
+(defnk ^:query hello [[:data name :- String]]
   (success {:message (str "Hello, " name)}))
 
-(def app (cqrs-api {:core {:handlers {:api #'hello-world}}}))
+(def app (cqrs-api {:core {:handlers {:api #'hello}}}))
 
 (defn start []
-  (server/run-server #'app {:port 3000})
-  (println "server running in port 3000"))
+  (server/run-server #'app {:port 3000}))
 
 ; ... or as a one-liner with vanilla Clojure
 ;
 ; (defn start []
 ;   (server/run-server
 ;    (cqrs-api
-;      {:core 
-;        {:handlers 
-;          {:api 
+;      {:core
+;        {:handlers
+;          {:api
 ;            (query
-;              {:name 'hello-world
-;               :input {:data {:name String}}
-;               :responses {:default {:schema {:result String}}}}
-;               (fn [context]
-;                 (success {:response (str "Hello, " (-> context :data :name))})))}}})
+;              {:name "hello"
+;               :handle (fn [{{:keys [name]} :data}]
+;                         (success {:message (str "Hello, " name)}))})}}})
 ;    {:port 3000}))

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
                  [ring-middleware-format "0.7.0"]
 
                  ;; client stuff, separate module?
-                 [clj-http "3.1.0"]]
+                 [clj-http "2.2.0"]]
   :profiles {:dev {:plugins [[lein-midje "3.2"]]
                    :source-paths ["dev-src" "src"]
                    :dependencies [[org.clojure/clojure "1.8.0"]

--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,13 @@
             :distribution :repo
             :comments "same as Clojure"}
   :dependencies [[prismatic/plumbing "0.5.3"]
-                 [prismatic/schema "1.1.1"]
+                 [prismatic/schema "1.1.2"]
                  [frankiesardo/linked "1.2.6"]
 
                  ;; http-stuff, separate module?
-                 [metosin/ring-swagger "0.22.8"]
+                 [metosin/ring-swagger "0.22.9"]
                  [metosin/ring-swagger-ui "2.1.4-0"]
-                 [metosin/ring-http-response "0.6.5"]
+                 [metosin/ring-http-response "0.7.0"]
                  [ring-middleware-format "0.7.0"]
 
                  ;; client stuff, separate module?

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                                   ; required when working with Java 1.6
                                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
                                   [midje "1.8.3"]]}
-             :perf {:jvm-opts ^:replace []}
+             :perf {:jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}
   :aliases {"all" ["with-profile" "dev:dev,1.7"]
             "perf" ["with-profile" "default,dev,perf"]

--- a/src/kekkonen/api.clj
+++ b/src/kekkonen/api.clj
@@ -24,17 +24,16 @@
                            :version "0.0.1"}}}})
 
 (defn api [options]
-  (s/with-fn-validation
-    (let [options (s/validate Options (kc/deep-merge-map-like +default-options+ options))
-          api-handlers (-> options :api :handlers)
-          swagger-data (merge (-> options :swagger :data) (mw/api-info (:mw options)))
-          swagger-options (-> options :swagger)
-          swagger-handler (ks/swagger-handler swagger-data swagger-options)
-          dispatcher (cond-> (k/dispatcher (:core options))
-                             api-handlers (k/inject api-handlers)
-                             swagger-handler (k/inject swagger-handler))]
-      (mw/wrap-api
-        (r/routes
-          [(r/ring-handler dispatcher (:ring options))
-           (ks/swagger-ui swagger-options)])
-        (:mw options)))))
+  (let [options (s/validate Options (kc/deep-merge-map-like +default-options+ options))
+        api-handlers (-> options :api :handlers)
+        swagger-data (merge (-> options :swagger :data) (mw/api-info (:mw options)))
+        swagger-options (-> options :swagger)
+        swagger-handler (ks/swagger-handler swagger-data swagger-options)
+        dispatcher (cond-> (k/dispatcher (:core options))
+                           api-handlers (k/inject api-handlers)
+                           swagger-handler (k/inject swagger-handler))]
+    (mw/wrap-api
+      (r/routes
+        [(r/ring-handler dispatcher (:ring options))
+         (ks/swagger-ui swagger-options)])
+      (:mw options))))

--- a/src/kekkonen/common.clj
+++ b/src/kekkonen/common.clj
@@ -65,6 +65,9 @@
 ;; Others
 ;;
 
+(defn join [& x-or-xs]
+  (flatten x-or-xs))
+
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. `keys` is a sequence of keys. Any empty maps that result

--- a/src/kekkonen/common.clj
+++ b/src/kekkonen/common.clj
@@ -68,6 +68,9 @@
 (defn join [& x-or-xs]
   (flatten x-or-xs))
 
+(defn vectorize [x]
+  (if (sequential? x) (vec x) [x]))
+
 (defn dissoc-in
   "Dissociates an entry from a nested associative structure returning a new
   nested structure. `keys` is a sequence of keys. Any empty maps that result

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -394,10 +394,10 @@
    (fn [context]
      (let [{:keys [handle input output]} (::handler context)
            mode (::mode context)
-           dispatcher (::dispatcher context)
-           input-matcher (-> dispatcher :coercion :input)]
-       (let [context (if (#{:validate :invoke} mode) (input-coerce! context input input-matcher) context)
-             response (if (#{:invoke} mode)
+           dispatcher (::dispatcher context)]
+       (let [context (if (#{:validate :invoke} mode)
+                       (input-coerce! context input) context)
+             response (if (= :invoke mode)
                         (as-> (handle context) response
                               (if (and output (-> dispatcher :coercion :output))
                                 (coerce! output (-> dispatcher :coercion :output) response nil ::response)

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -360,11 +360,10 @@
      context)))
 
 (defn prepare [dispatcher handler context]
-  (if (::dispatcher context)
-    context
-    (assoc (kc/deep-merge (:context dispatcher) context)
-      ::dispatcher dispatcher
-      ::handler handler)))
+  (let [ctx (assoc (kc/deep-merge (:context dispatcher) context)
+              ::dispatcher dispatcher
+              ::handler handler)]
+    ctx))
 
 ;;
 ;; Dispatching to handlers

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -362,11 +362,9 @@
 (defn prepare [dispatcher handler context]
   (if (::dispatcher context)
     context
-    (kc/deep-merge
-      (:context dispatcher)
-      context
-      {::dispatcher dispatcher
-       ::handler handler})))
+    (assoc (kc/deep-merge (:context dispatcher) context)
+      ::dispatcher dispatcher
+      ::handler handler)))
 
 ;;
 ;; Dispatching to handlers

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -359,7 +359,7 @@
              context))
      context)))
 
-(defn initialize-context [dispatcher handler context]
+(defn prepare [dispatcher handler context]
   (kc/deep-merge
     (:context dispatcher)
     context
@@ -400,7 +400,7 @@
                                 response)))]
          (assoc context :response response))))})
 
-(defn- execute [context interceptors]
+(defn execute [context interceptors]
   (-> context
       (interceptor/enqueue interceptors)
       (interceptor/execute {:pre-enter pre-enter})))
@@ -408,7 +408,7 @@
 (defn- dispatch [dispatcher mode action context]
   (if-let [{:keys [interceptors] :as handler} (some-handler dispatcher action)]
     (let [interceptors (concat (:interceptors dispatcher) interceptors [(intercept-handler mode)])
-          context (-> (initialize-context dispatcher handler context) (execute interceptors))]
+          context (-> (prepare dispatcher handler context) (execute interceptors))]
       (if (contains? context :response)
         (:response context)
         (invalid-action! action)))

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -400,13 +400,16 @@
                                 response)))]
          (assoc context :response response))))})
 
+(defn enqueue [context interceptors]
+  (interceptor/enqueue context interceptors))
+
 ;; pre-enter adds +30% overhead, pre-compile into interceptors!
 (defn execute [context interceptors]
   (-> context
       (interceptor/enqueue interceptors)
       (interceptor/execute {:pre-enter pre-enter})))
 
-(defn- dispatch [dispatcher mode action context]
+(defn dispatch [dispatcher mode action context]
   (if-let [{:keys [interceptors] :as handler} (some-handler dispatcher action)]
     (let [interceptors (concat (:interceptors dispatcher) interceptors [(intercept-handler mode)])
           context (-> (prepare dispatcher handler context) (execute interceptors))]

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -400,6 +400,7 @@
                                 response)))]
          (assoc context :response response))))})
 
+;; pre-enter adds +30% overhead, pre-compile into interceptors!
 (defn execute [context interceptors]
   (-> context
       (interceptor/enqueue interceptors)

--- a/src/kekkonen/core.clj
+++ b/src/kekkonen/core.clj
@@ -360,11 +360,13 @@
      context)))
 
 (defn prepare [dispatcher handler context]
-  (kc/deep-merge
-    (:context dispatcher)
+  (if (::dispatcher context)
     context
-    {::dispatcher dispatcher
-     ::handler handler}))
+    (kc/deep-merge
+      (:context dispatcher)
+      context
+      {::dispatcher dispatcher
+       ::handler handler})))
 
 ;;
 ;; Dispatching to handlers

--- a/src/kekkonen/cqrs.clj
+++ b/src/kekkonen/cqrs.clj
@@ -32,12 +32,16 @@
 ;;
 
 (s/defn command
-  [meta :- k/KeywordMap, f :- k/Function]
-  (vary-meta f merge {:type :command} meta))
+  ([meta :- k/KeywordMap]
+    (command (dissoc meta :handle) (:handle meta)))
+  ([meta :- k/KeywordMap, f :- k/Function]
+    (k/handler (merge meta {:type :command}) f)))
 
 (s/defn query
-  [meta :- k/KeywordMap, f :- k/Function]
-  (vary-meta f merge {:type :query} meta))
+  ([meta :- k/KeywordMap]
+    (query (dissoc meta :handle) (:handle meta)))
+  ([meta :- k/KeywordMap, f :- k/Function]
+    (k/handler (merge meta {:type :query}) f)))
 
 ;;
 ;; api

--- a/src/kekkonen/interceptor.clj
+++ b/src/kekkonen/interceptor.clj
@@ -1,0 +1,117 @@
+;; ns partially copy-pasted from pedestal. Will be merged later.
+(ns kekkonen.interceptor
+  (:import [clojure.lang PersistentQueue]
+           [java.util.concurrent.atomic AtomicLong]))
+
+(def ^:private ^AtomicLong execution-id (AtomicLong.))
+
+(defn- interceptor-name [interceptor]
+  (let [n (:name interceptor)]
+    (cond
+      (keyword? n) n
+      (string? n) n
+      (nil? n) (pr-str interceptor)
+      :else (throw (ex-info (str "Name must be string, keyword or nil; Got: " (pr-str n)) {:name n})))))
+
+(defn- begin [context]
+  (if (contains? context ::execution-id)
+    context
+    (let [execution-id (.incrementAndGet execution-id)]
+      (assoc context ::execution-id execution-id))))
+
+(defn- end [context]
+  (if (contains? context ::execution-id)
+    (dissoc context ::stack ::execution-id)
+    context))
+
+(defn- throwable->ex-info [^Throwable t execution-id interceptor stage]
+  (ex-info (str "Interceptor Exception: " (.getMessage t))
+           (merge {:execution-id execution-id
+                   :stage stage
+                   :interceptor (interceptor-name interceptor)
+                   :exception-type (keyword (pr-str (type t)))
+                   :exception t}
+                  (ex-data t))
+           t))
+
+(defn- try-f [context interceptor stage]
+  (let [execution-id (::execution-id context)]
+    (if-let [f (get interceptor stage)]
+      (try
+        (f context)
+        (catch Throwable t
+          (assoc context ::error (throwable->ex-info t execution-id interceptor stage))))
+      context)))
+
+(defn- enter-all [context]
+  (loop [context context]
+    (let [queue (::queue context)
+          stack (::stack context)]
+      (if (empty? queue)
+        context
+        (let [interceptor (peek queue)
+              context (-> context
+                          (assoc ::queue (pop queue))
+                          (assoc ::stack (conj stack interceptor))
+                          (try-f interceptor :enter))]
+          (cond
+            (::error context) (dissoc context ::queue)
+            true (recur context)))))))
+
+(defn- try-error [context interceptor]
+  (let [execution-id (::execution-id context)]
+    (if-let [error-fn (get interceptor :error)]
+      (let [ex (::error context)]
+        (try
+          (error-fn (dissoc context ::error) ex)
+          (catch Throwable t
+            (if (identical? (type t) (type (:exception ex)))
+              context
+              (-> context
+                  (assoc ::error (throwable->ex-info t execution-id interceptor :error))
+                  (update-in [::suppressed] conj ex))))))
+      context)))
+
+(defn- leave-all [context]
+  (loop [context context]
+    (let [stack (::stack context)]
+      (if (empty? stack)
+        context
+        (let [interceptor (peek stack)
+              context (assoc context ::stack (pop stack))
+              context (if (::error context)
+                        (try-error context interceptor)
+                        (try-f context interceptor :leave))]
+          (recur context))))))
+
+;;
+;; Public api
+;;
+
+(defn interceptor? [x]
+  (if-let [int-vals (vals (select-keys x [:enter :leave :error]))]
+    (and (some identity int-vals)
+         (every? fn? (remove nil? int-vals))
+         (or (interceptor-name x) true)
+         true)
+    false))
+
+(defn enqueue [context interceptors]
+  {:pre (every? interceptor? interceptors)}
+  (update-in context [::queue]
+             (fnil into PersistentQueue/EMPTY)
+             interceptors))
+
+(defn terminate [context]
+  (dissoc context ::queue))
+
+(defn execute [context]
+  (let [context (some-> context
+                        begin
+                        enter-all
+                        terminate
+                        leave-all
+                        end)]
+    (if-let [ex (::error context)]
+      (throw ex)
+      context)))

--- a/src/kekkonen/interceptor.clj
+++ b/src/kekkonen/interceptor.clj
@@ -98,7 +98,6 @@
     false))
 
 (defn enqueue [context interceptors]
-  {:pre (every? interceptor? interceptors)}
   (update-in context [::queue]
              (fnil into PersistentQueue/EMPTY)
              interceptors))

--- a/src/kekkonen/middleware.clj
+++ b/src/kekkonen/middleware.clj
@@ -43,7 +43,9 @@
 
 (defn coerce-error-handler [f]
   (fn [_ data _]
-    (f (-> data (dissoc :schema) (update-in [:error] #(stringify (su/error-val %)))))))
+    (f (-> data
+           (select-keys [:value :type :error :in #_:execution-id #_:stage])
+           (update-in [:error] #(stringify (su/error-val %)))))))
 
 (def ^:private missing-route-handler (constantly (r/not-found)))
 (def ^:private request-validation-handler (coerce-error-handler r/bad-request))

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -218,13 +218,13 @@
                s/Keyword s/Any}
        :description "Return a list of available handlers from kekkonen.ns namespace"
        :handle (fn [{{{ns :kekkonen.ns} :query-params} :request :as context}]
-                 (ok (->> context
+                 (ok (-> context
                           k/get-dispatcher
-                          (p/<- (k/available-handlers ns (clean-context context)))
-                          (filter (p/fn-> :ring))
+                         (k/available-handlers ns (clean-context context))
+                         (->> (filter (p/fn-> :ring))
                           (remove (p/fn-> :ns (= :kekkonen)))
                           (remove (p/fn-> :meta :no-doc))
-                          (map k/public-handler))))})
+                              (map k/public-handler)))))})
     (k/handler
       {:name "actions"
        :type ::handler
@@ -242,11 +242,11 @@
                s/Keyword s/Any}
        :description "Return a map of action -> error of all available handlers"
        :handle (fn [{{{mode :kekkonen.mode ns, :kekkonen.ns} :query-params} :request :as context}]
-                 (ok (->> context
+                 (ok (-> context
                           k/get-dispatcher
-                          (p/<- (k/dispatch-handlers (or mode :check) ns (clean-context context)))
-                          (filter (p/fn-> first :ring))
+                         (k/dispatch-handlers (or mode :check) ns (clean-context context))
+                         (->> (filter (p/fn-> first :ring))
                           (remove (p/fn-> first :ns (= :kekkonen)))
                           (remove (p/fn-> first :meta :no-doc))
                           (map (fn [[k v]] [(:action k) (k/stringify-schema v)]))
-                          (into {}))))})]})
+                              (into {})))))})]})

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -7,7 +7,8 @@
             [ring.swagger.json-schema :as rsjs]
             [ring.util.http-response :refer [ok]]
             [plumbing.core :as p]
-            [plumbing.map :as pm])
+            [plumbing.map :as pm]
+            [kekkonen.interceptor :as interceptor])
   (:import [kekkonen.core Dispatcher]
            [java.util HashMap Map]))
 
@@ -234,7 +235,7 @@
           (if (some-> ring :methods (contains? request-method))
             (let [mode (request-mode request)]
               (-> {:request request}
-                  (k/enqueue interceptors)
+                  (interceptor/enqueue interceptors)
                   (->> (k/dispatch dispatcher mode action))))))))))
 
 ;;

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -130,8 +130,9 @@
                  (copy-parameters handler)))})
 
 (defn- coerce-response [options]
-  {:leave (fn [ctx]
-            (let [handler (::k/handler ctx)]
+  {:leave (fn [{:keys [::k/handler ::k/mode] :as ctx}]
+            (if (= :validate mode)
+              (update ctx :response ok)
               (update ctx :response #(coerce-response! % handler options))))})
 
 (defn- clean-context [context]
@@ -166,8 +167,7 @@
             (let [mode (request-mode request)]
               (-> {:request request}
                   (k/enqueue interceptors)
-                  (->> (k/dispatch dispatcher mode action))
-                  (cond-> (= :validate mode) (ok))))))))))
+                  (->> (k/dispatch dispatcher mode action))))))))))
 
 (s/defn routes :- k/Function
   "Creates a ring handler of multiples handlers, matches in order."

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -67,11 +67,11 @@
 (defn- coerce-response! [response handler options]
   (if-let [responses (-> handler :meta :responses)]
     (let [status (or (:status response) 200)
-          schema (get-in responses [status :schema])
-          matcher (get-in options [:coercion :body-params])
-          value (:body response)]
+          schema (get-in responses [status :schema])]
       (if schema
-        (let [coerced (k/coerce! schema matcher value :response ::response)]
+        (let [value (:body response)
+              matcher (get-in options [:coercion :body-params])
+              coerced (k/coerce! schema matcher value :response ::response)]
           (assoc response :body coerced))
         response))
     response))

--- a/test/kekkonen/api_test.clj
+++ b/test/kekkonen/api_test.clj
@@ -53,7 +53,7 @@
               response => ok?
               (parse response) => nil))
 
-          (fact "with invalid parameters"
+         (fact "with invalid parameters"
             (let [response (app {:uri "/api/public/plus"
                                  :request-method :post
                                  :headers {"kekkonen.mode" "validate"}})]
@@ -211,7 +211,7 @@
     (fact "swagger-object"
       (fact "without role"
         (let [response (app {:uri "/swagger.json" :request-method :get})
-              body (parse response)]
+              body (parse-swagger response)]
           response => ok?
           body => (contains
                     {:swagger "2.0"
@@ -229,7 +229,7 @@
                                 "application/transit+msgpack"]
                      :definitions anything
                      :paths (contains
-                              {:/api/public/plus
+                              {"/api/public/plus"
                                (just
                                  {:post
                                   (just
@@ -257,43 +257,43 @@
             body => (contains
                       {:paths
                        (just
-                         {:/api/public/plus anything
-                          :/api/public/nada anything
-                          :/kekkonen/handler anything
-                          :/kekkonen/handlers anything
-                          :/kekkonen/actions anything})}))
+                         {"/api/public/plus" anything
+                          "/api/public/nada" anything
+                          "/kekkonen/handler" anything
+                          "/kekkonen/handlers" anything
+                          "/kekkonen/actions" anything})}))
 
           (fact "secret endpoints are not documented"
             body =not=> (contains
                           {:paths
                            (contains
-                             {:/api/secret/plus anything})})))
+                             {"/api/secret/plus" anything})})))
 
         (fact "with ns-filter"
           (let [response (app {:uri "/swagger.json"
                                :request-method :get
                                :query-params {::role :admin
                                               :ns "api.public"}})
-                body (parse response)]
+                body (parse-swagger response)]
             response => ok?
             body => (contains
                       {:paths
                        (just
-                         {:/api/public/plus anything
-                          :/api/public/nada anything})})))))
+                         {"/api/public/plus" anything
+                          "/api/public/nada" anything})})))))
 
     (fact "with role"
       (let [response (app {:uri "/swagger.json"
                            :request-method :get
                            :query-params {::role :admin}})
-            body (parse response)]
+            body (parse-swagger response)]
         response => ok?
 
         (fact "secret endpoints are also documented"
           body => (contains
                     {:paths
                      (contains
-                       {:/api/secret/plus anything})}))))
+                       {"/api/secret/plus" anything})}))))
 
     (fact "swagger-ui"
       (let [response (app {:uri "/api-docs" :request-method :get})]

--- a/test/kekkonen/core_test.clj
+++ b/test/kekkonen/core_test.clj
@@ -220,11 +220,11 @@
   (fact "can't be created without handlers"
     (k/dispatcher {}) => (throws?))
 
-  (fact "can't be created with root level handlers"
-    (k/dispatcher {:handlers 'kekkonen.core-test}) => (throws?))
+  (fact "can be created with root level handlers (since 0.3.0)"
+    (k/dispatcher {:handlers 'kekkonen.core-test}) => some?)
 
   (fact "can be created with namespaced handlers"
-    (k/dispatcher {:handlers {:test 'kekkonen.core-test}}) => truthy)
+    (k/dispatcher {:handlers {:test 'kekkonen.core-test}}) => some?)
 
   (fact "with handlers and context"
     (let [d (k/dispatcher {:context {:components {:db (atom #{})}}

--- a/test/kekkonen/interceptor_test.clj
+++ b/test/kekkonen/interceptor_test.clj
@@ -74,3 +74,12 @@
                              :exception (partial instance? Exception)
                              :stage :enter
                              :exception-type :clojure.lang.ExceptionInfo}))))
+
+(facts "pre-enter & pre-leave"
+  (-> {:x 2}
+      (i/enqueue [{:enter #(update % :x inc)}
+                  {:enter #(update % :x inc)}
+                  {:leave #(update % :x inc)}])
+      (i/execute {:pre-enter (fn [ctx _] (update ctx :enter (fnil inc 0)))
+                  :pre-leave (fn [ctx _] (update ctx :leave (fnil dec 0)))}))
+  => {:x 5, :enter 2, :leave -1})

--- a/test/kekkonen/interceptor_test.clj
+++ b/test/kekkonen/interceptor_test.clj
@@ -74,12 +74,3 @@
                              :exception (partial instance? Exception)
                              :stage :enter
                              :exception-type :clojure.lang.ExceptionInfo}))))
-
-(facts "pre-enter & pre-leave"
-  (-> {:x 2}
-      (i/enqueue [{:enter #(update % :x inc)}
-                  {:enter #(update % :x inc)}
-                  {:leave #(update % :x inc)}])
-      (i/execute {:pre-enter (fn [ctx _] (update ctx :enter (fnil inc 0)))
-                  :pre-leave (fn [ctx _] (update ctx :leave (fnil dec 0)))}))
-  => {:x 5, :enter 2, :leave -1})

--- a/test/kekkonen/interceptor_test.clj
+++ b/test/kekkonen/interceptor_test.clj
@@ -1,0 +1,62 @@
+(ns kekkonen.interceptor-test
+  (:require [midje.sweet :refer :all]
+            [kekkonen.interceptor :as i]))
+
+(defn not-executed [_]
+  (throw (ex-info "not-run" {})))
+
+(facts "interceptor?"
+  (i/interceptor? {:enter identity}) => true
+  (i/interceptor? {:leave identity}) => true
+  (i/interceptor? {:error identity}) => true
+  (i/interceptor? {}) => false)
+
+(facts "queues"
+  (let [interceptor1 {:enter identity, :leave identity}
+        interceptor2 {:enter identity, :leave identity}]
+    (fact "enqueue"
+      (i/enqueue {} [interceptor1]) => {::i/queue [interceptor1]}
+      (i/enqueue {} [interceptor1 interceptor2]) => {::i/queue [interceptor1 interceptor2]})
+    (fact "terminate"
+      (i/terminate (i/enqueue {} [interceptor1 interceptor2])) => {})))
+
+(facts "execute"
+  (facts "are executed in order"
+    (-> {:x 2}
+        (i/enqueue [{:enter #(update % :x inc)}
+                    {:enter #(update % :x (partial * 2))
+                     :leave #(update % :x (partial * 2))}
+                    {:leave #(update % :x dec)}])
+        (i/execute)) => {:x 10})
+
+  (fact "with terminate, future steps are not executed"
+    (-> {:x 2}
+        (i/enqueue [{:enter #(update % :x inc)
+                     :leave #(update % :x inc)}
+                    {:enter i/terminate
+                     :leave #(update % :x (partial * 2))}
+                    {:leave not-executed}])
+        (i/execute)) => {:x 7})
+
+  (fact "setting context to nil, all execution is stopped"
+    (-> {:x 2}
+        (i/enqueue [{:enter #(update % :x inc)
+                     :error (fn [context e]
+                              (println context "-" e))
+                     :leave not-executed}
+                    {:enter (constantly nil)
+                     :leave not-executed}
+                    {:leave not-executed}])
+        (i/execute)) => nil)
+
+  (fact "on exception"
+    (fact "can be caught"
+      (-> {:x 2}
+          (i/enqueue [{:enter #(update % :x inc)
+                       :error (fn [context e]
+                                (assoc context ::exception true))
+                       :leave not-executed}
+                      {:enter (fn [_] (throw (ex-info "fail" {:reason "too many men"})))
+                       :leave not-executed}
+                      {:leave not-executed}])
+          (i/execute))) => {:x 3 ::exception true}))

--- a/test/kekkonen/interceptor_test.clj
+++ b/test/kekkonen/interceptor_test.clj
@@ -41,8 +41,7 @@
   (fact "setting context to nil, all execution is stopped"
     (-> {:x 2}
         (i/enqueue [{:enter #(update % :x inc)
-                     :error (fn [context e]
-                              (println context "-" e))
+                     :error not-executed
                      :leave not-executed}
                     {:enter (constantly nil)
                      :leave not-executed}
@@ -59,4 +58,4 @@
                       {:enter (fn [_] (throw (ex-info "fail" {:reason "too many men"})))
                        :leave not-executed}
                       {:leave not-executed}])
-          (i/execute))) => {:x 3 ::exception true}))
+          (i/execute)) => {:x 3 ::exception true})))

--- a/test/kekkonen/midje.clj
+++ b/test/kekkonen/midje.clj
@@ -13,7 +13,13 @@
            mdata (if data (select-keys data (vec (keys m))))]
        (and
          (not (nil? x))
-         (= mdata m))))))
+         (every?
+           (fn [[k v]]
+             (let [v' (get mdata k)]
+               (if (fn? v)
+                 (v v')
+                 (= v v'))))
+           m))))))
 
 (def schema-error? (throws? {:type ::s/error}))
 (def missing-route? (throws? {:type ::k/dispatch}))

--- a/test/kekkonen/perf.clj
+++ b/test/kekkonen/perf.clj
@@ -60,24 +60,25 @@
 (def r2 (kr/ring-handler d2))
 (def r3 (kr/ring-handler d2 {:coercion nil}))
 
+(def data {:uri "/api/math/plus1"
+           :request-method :post
+           :body-params {:x 10, :y 20}})
+
 (defn ring-bench []
 
   (title "ring & dispatcher coercion")
-  (cc/quick-bench (r1 {:uri "/api/math/plus1"
-                       :request-method :post
-                       :body-params {:x 10, :y 20}}))
+  (assert (= 30 (-> data r1 :body :result)))
+  (cc/quick-bench (r1 data))
   ; 20.7µs => 17.1µs => 11.3µs
 
   (title "ring coercion")
-  (cc/quick-bench (r2 {:uri "/api/math/plus1"
-                       :request-method :post
-                       :body-params {:x 10, :y 20}}))
+  (assert (= 30 (-> data r2 :body :result)))
+  (cc/quick-bench (r2 data))
   ; 15.7µs => 12.2µs => 7.6µs
 
   (title "no coercion")
-  (cc/quick-bench (r3 {:uri "/api/math/plus1"
-                       :request-method :post
-                       :body-params {:x 10, :y 20}}))
+  (assert (= 30 (-> data r3 :body :result)))
+  (cc/quick-bench (r3 data))
   ; ................ => 3.5µs
 
   (println))

--- a/test/kekkonen/perf.clj
+++ b/test/kekkonen/perf.clj
@@ -38,11 +38,11 @@
 
   (title "with coercion")
   (cc/quick-bench (k/invoke d1 :api.math/plus1 {:data {:x 10, :y 20}}))
-  ; 28.0µs => 8.2µs (memoized) => 7.0µs (lookup)
+  ; 28.0µs => 8.2µs (memoized) => 7.0µs (lookup) => 7.2µs (leave) => 10.0µs (pedestal)
 
   (title "without coercion")
   (cc/quick-bench (k/invoke d2 :api.math/plus1 {:data {:x 10, :y 20}}))
-  ; 3.7µs -> 3.7µs (memoized) => 2.0µs (lookup)
+  ; 3.7µs -> 3.7µs (memoized) => 2.0µs (lookup) => 2.1µs (leave) => 4.2µs (pedestal)
 
   (title "clojure multimethod")
   (cc/quick-bench (multi-method-invoke :api.math/plus1 {:data {:x 10, :y 20}}))
@@ -69,17 +69,17 @@
   (title "ring & dispatcher coercion")
   (assert (= 30 (-> data r1 :body :result)))
   (cc/quick-bench (r1 data))
-  ; 20.7µs => 17.1µs => 11.3µs
+  ; 20.7µs => 17.1µs => 11.3µs => 14.7µs (leave) => 19.2 (pedestal)
 
   (title "ring coercion")
   (assert (= 30 (-> data r2 :body :result)))
   (cc/quick-bench (r2 data))
-  ; 15.7µs => 12.2µs => 7.6µs
+  ; 15.7µs => 12.2µs => 7.6µs => 10.4µs (leave) => 13.3µs (pedestal)
 
   (title "no coercion")
   (assert (= 30 (-> data r3 :body :result)))
   (cc/quick-bench (r3 data))
-  ; ................ => 3.5µs
+  ; ................ => 3.5µs => 3.9 (leave) => 9.5µs (pedestal)
 
   (println))
 

--- a/test/kekkonen/perf.clj
+++ b/test/kekkonen/perf.clj
@@ -38,11 +38,11 @@
 
   (title "with coercion")
   (cc/quick-bench (k/invoke d1 :api.math/plus1 {:data {:x 10, :y 20}}))
-  ; 28.0µs => 8.2µs (memoized) => 7.0µs (lookup) => 7.2µs (leave) => 10.0µs (pedestal)
+  ; 28.0µs => 8.2µs (memoized) => 7.0µs (lookup) => 7.2µs (leave) => 10.0µs (pedestal) => 9.6µs (precompiled)
 
   (title "without coercion")
   (cc/quick-bench (k/invoke d2 :api.math/plus1 {:data {:x 10, :y 20}}))
-  ; 3.7µs -> 3.7µs (memoized) => 2.0µs (lookup) => 2.1µs (leave) => 4.2µs (pedestal)
+  ; 3.7µs -> 3.7µs (memoized) => 2.0µs (lookup) => 2.1µs (leave) => 4.2µs (pedestal) => 3.9µs (precompiled)
 
   (title "clojure multimethod")
   (cc/quick-bench (multi-method-invoke :api.math/plus1 {:data {:x 10, :y 20}}))
@@ -69,17 +69,17 @@
   (title "ring & dispatcher coercion")
   (assert (= 30 (-> data r1 :body :result)))
   (cc/quick-bench (r1 data))
-  ; 20.7µs => 17.1µs => 11.3µs => 14.7µs (leave) => 19.2 (pedestal)
+  ; 20.7µs => 17.1µs => 11.3µs => 14.7µs (leave) => 19.2 (pedestal) => 19.0µs (precompiled)
 
   (title "ring coercion")
   (assert (= 30 (-> data r2 :body :result)))
   (cc/quick-bench (r2 data))
-  ; 15.7µs => 12.2µs => 7.6µs => 10.4µs (leave) => 13.3µs (pedestal)
+  ; 15.7µs => 12.2µs => 7.6µs => 10.4µs (leave) => 13.3µs (pedestal) => 13.1µs (precompiled)
 
   (title "no coercion")
   (assert (= 30 (-> data r3 :body :result)))
   (cc/quick-bench (r3 data))
-  ; ................ => 3.5µs => 3.9 (leave) => 9.5µs (pedestal)
+  ; ................ => 3.5µs => 3.9 (leave) => 9.5µs (pedestal) => 9.1µs (precompiled)
 
   (println))
 

--- a/test/kekkonen/ring_test.clj
+++ b/test/kekkonen/ring_test.clj
@@ -179,8 +179,8 @@
 
         (app {:uri "/api/plus"
               :request-method :post
-              :query-params {:x "1", :y "2"}}) => (throws ClassCastException)))
-
+              :query-params {:x "1", :y "2"}}) => (throws-interceptor-exception?
+                                                    {:exception-type :java.lang.ClassCastException})))
     (fact "if handler is dependent on :data-input, default coercion is applies"
       (let [app (r/ring-handler
                   (k/dispatcher {:handlers {:api (k/handler
@@ -200,7 +200,8 @@
 
       (app {:uri "/api/plus"
             :request-method :post
-            :query-params {:x "1", :y "2"}}) => (throws ClassCastException)))
+            :query-params {:x "1", :y "2"}}) => (throws-interceptor-exception?
+                                                  {:exception-type :java.lang.ClassCastException})))
 
   (fact "all ring & core coercions can be disabled"
     (let [app (r/ring-handler
@@ -209,7 +210,8 @@
 
       (app {:uri "/api/plus"
             :request-method :post
-            :query-params {:x "1", :y "2"}}) => (throws ClassCastException))))
+            :query-params {:x "1", :y "2"}}) => (throws-interceptor-exception?
+                                                  {:exception-type :java.lang.ClassCastException}))))
 
 (facts "mapping"
   (facts "default body-params -> data"


### PR DESCRIPTION
Re-implemented all interceptors as Pedestal-style interceptors with `:name`, `:enter`, `:leave` and `:error`.  Interceptors are defined in a separate `kekkonen.interceptors` namespace which copy-pasted (and simplified) from Pedestal 0.5.0. Will be merged in later(?). Internals are no much simpler and robust as ring-handler simply enqueues it's interceptors into context and call then the dispatcher. All interceptors are precompiled for better perf, which is 30% less than before for the common (ring-)case, due to the generic nature of the interceptor pipeline. Also:

* Removed `:interceptors` from the `Dispatcher`, as they are now precompiled into handlers
* Extra meta-data has been removed from the handlers: `:ns-meta`, `:all-meta`, `:handler-input` & `:user-input`

```clj
(defnk ^:handler plus
  {:interceptors [{:enter (fnk [[:data y :- s/Int] :as ctx]
                            (update-in ctx [:data :x] (partial + y)))}]}
  [[:data x :- s/Int]]
  (inc x))

(some-handler (dispatcher {:handlers {:math #'plus}}) :math/plus)
;{:ns :math
; :name :plus
; :action :math/plus
; :description nil
; :meta {:interceptors [{:enter #object[...]}]}
; :type :handler
; :output s/Any
; :input {:data {:x s/Int s/Keyword s/Any :y s/Int} Keyword s/Any}
; :handle #object[...]
; :source-map {:line 619
;              :column 1
;              :file "/Users/tommi/projects/metosin/kekkonen/src/kekkonen/core.clj"
;              :ns kekkonen.core
;              :name plus}
; :interceptors [{:input {:data {:y s/Int s/Keyword s/Any} s/Keyword s/Any}
;                 :output Any
;                 :enter #object[...]}
;                {:name ":kekkonen.core/handle"
;                 :enter #object[...]}]}
