### PR TITLE
Better file-upload support

### DIFF
--- a/dev-src/example/cqrs.clj
+++ b/dev-src/example/cqrs.clj
@@ -106,7 +106,7 @@
   {:interceptors [[upload/multipart-params]]
    :type ::ring/handler
    ::ring/method :put
-   :consumes ["multipart/form-data"]}
+   ::ring/consumes ["multipart/form-data"]}
   [[:request [:multipart-params file :- upload/TempFileUpload]]]
   (success (dissoc file :tempfile)))
 

--- a/dev-src/example/cqrs.clj
+++ b/dev-src/example/cqrs.clj
@@ -3,7 +3,9 @@
             [kekkonen.cqrs :refer :all]
             [plumbing.core :refer [defnk]]
             [schema.core :as s]
-            [clojure.set :as set]))
+            [clojure.set :as set]
+            [kekkonen.upload :as upload]
+            [kekkonen.ring :as ring]))
 
 ;;
 ;; Security
@@ -99,6 +101,15 @@
   [[:components counter]]
   (success {:result (swap! counter (partial + 10))}))
 
+(defnk upload
+  "upload a file to the server"
+  {:interceptors [[upload/multipart-params]]
+   :type ::ring/handler
+   ::ring/method :put
+   :consumes ["multipart/form-data"]}
+  [[:request [:multipart-params file :- upload/TempFileUpload]]]
+  (success (dissoc file :tempfile)))
+
 ;;
 ;; Application
 ;;
@@ -108,6 +119,7 @@
     {:swagger {:ui "/api-docs"
                :spec "/swagger.json"
                :data {:info {:title "Kekkonen"}}}
+     :api {:handlers {:http #'upload}}
      :core {:handlers {:api {:item [#'get-items #'add-item #'reset-items]
                              :calculator [#'plus #'times #'increment]
                              :security #'get-user

--- a/project.clj
+++ b/project.clj
@@ -24,6 +24,8 @@
                                   [http-kit "2.1.19"]
                                   ; required when working with Java 1.6
                                   [org.codehaus.jsr166-mirror/jsr166y "1.7.0"]
+                                  ; uploads
+                                  [javax.servlet/servlet-api "2.5"]
                                   [midje "1.8.3"]]}
              :perf {:jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]}
              :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}}

--- a/src/kekkonen/api.clj
+++ b/src/kekkonen/api.clj
@@ -8,7 +8,7 @@
 
 (s/defschema Options
   {:core k/KeywordMap
-   (s/optional-key :api) {:handlers k/KeywordMap}
+   (s/optional-key :api) {:handlers s/Any}
    (s/optional-key :ring) r/Options
    (s/optional-key :mw) k/KeywordMap
    (s/optional-key :swagger) ks/Options})

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -33,6 +33,7 @@
               :path-params rsc/query-schema-coercion-matcher
               :form-params rsc/query-schema-coercion-matcher
               :header-params rsc/query-schema-coercion-matcher
+              :multipart-params rsc/query-schema-coercion-matcher
               :body-params rsc/json-schema-coercion-matcher}
    :interceptors []})
 

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -41,6 +41,8 @@
               :output nil}
    :meta {::disable-mode nil
           ::method nil
+          :consumes nil
+          :produces nil
           :responses nil}})
 
 ;;

--- a/src/kekkonen/ring.clj
+++ b/src/kekkonen/ring.clj
@@ -41,8 +41,8 @@
               :output nil}
    :meta {::disable-mode nil
           ::method nil
-          :consumes nil
-          :produces nil
+          ::consumes nil
+          ::produces nil
           :responses nil}})
 
 ;;

--- a/src/kekkonen/swagger.clj
+++ b/src/kekkonen/swagger.clj
@@ -6,7 +6,7 @@
             [kekkonen.core :as k]
             [kekkonen.common :as kc]
             [plumbing.core :as p]
-            [kekkonen.ring :as r]))
+            [kekkonen.ring :as ring]))
 
 (s/defschema Options
   {(s/optional-key :ui) (s/maybe s/Str)
@@ -18,7 +18,7 @@
 (defn transform-handler
   "Transforms a handler into ring-swagger path->method->operation map."
   [handler]
-  (let [{:keys [description ns ring] {:keys [summary responses produces consumes no-doc]} :meta} handler
+  (let [{:keys [description ns ring] {:keys [summary responses ::ring/produces ::ring/consumes no-doc]} :meta} handler
         {:keys [parameters input methods uri]} ring
         ;; copy back the mappings to get right request requirements
         input (reduce kc/copy-from-to input parameters)
@@ -79,7 +79,7 @@
        :handle (fn [{:keys [request] :as context}]
                  (let [dispatcher (k/get-dispatcher context)
                        ns (some-> context :request :query-params :ns str keyword)
-                       handlers (k/available-handlers dispatcher ns (#'r/clean-context context))]
+                       handlers (k/available-handlers dispatcher ns (#'ring/clean-context context))]
                    (ok (swagger-object
                          (add-base-path request (ring-swagger handlers swagger))
                          (-> options :options :spec)))))})))

--- a/src/kekkonen/swagger.clj
+++ b/src/kekkonen/swagger.clj
@@ -6,8 +6,7 @@
             [kekkonen.core :as k]
             [kekkonen.common :as kc]
             [plumbing.core :as p]
-            [kekkonen.ring :as r]
-            [clojure.string :as str]))
+            [kekkonen.ring :as r]))
 
 (s/defschema Options
   {(s/optional-key :ui) (s/maybe s/Str)
@@ -19,11 +18,11 @@
 (defn transform-handler
   "Transforms a handler into ring-swagger path->method->operation map."
   [handler]
-  (let [{:keys [description ns ring] {:keys [summary responses no-doc]} :meta} handler
+  (let [{:keys [description ns ring] {:keys [summary responses produces consumes no-doc]} :meta} handler
         {:keys [parameters input methods uri]} ring
-        ;; deep-merge back the mappings to get right request requirements
-        input (reduce kc/deep-merge-from-to input parameters)
-        {:keys [body-params query-params path-params header-params]} (:request input)]
+        ;; copy back the mappings to get right request requirements
+        input (reduce kc/copy-from-to input parameters)
+        {:keys [body-params query-params path-params header-params multipart-params]} (:request input)]
 
     ;; discard handlers with :no-doc or without :ring metadata
     (if (and (not no-doc) ring)
@@ -34,11 +33,14 @@
                                        :summary description})
                       (if summary {:summary summary})
                       (if responses {:responses responses})
+                      (if produces {:produces produces})
+                      (if consumes {:consumes consumes})
                       {:parameters (kc/strip-nil-values
                                      {:body body-params
                                       :query query-params
                                       :path path-params
-                                      :header header-params})}))})))
+                                      :header header-params
+                                      :formData multipart-params})}))})))
 
 (s/defn ring-swagger :- rs2/Swagger
   "Creates a ring-swagger object out of handlers and extra info"

--- a/src/kekkonen/upload.clj
+++ b/src/kekkonen/upload.clj
@@ -1,0 +1,45 @@
+;; Original: https://github.com/metosin/ring-swagger/blob/master/src/ring/swagger/upload.clj
+(ns kekkonen.upload
+  (:require [schema.core :as s]
+            [ring.swagger.json-schema :as js]
+            [ring.middleware.multipart-params :as multipart-params]
+            [clojure.walk :as walk])
+  (:import [java.io File]))
+
+(defn multipart-params
+  ([]
+   (multipart-params {}))
+  ([options]
+   {:enter (fn [ctx]
+             (update
+               ctx
+               :request
+               (fn [request]
+                 (-> request
+                     (multipart-params/multipart-params-request options)
+                     (update :multipart-params walk/keywordize-keys)))))}))
+
+(defrecord Upload [m]
+
+  s/Schema
+  (spec [_]
+    (s/spec m))
+  (explain [_]
+    (cons 'file m))
+
+  js/JsonSchema
+  (convert [_ _]
+    {:type "file"}))
+
+(def TempFileUpload
+  "Schema for file param created by ring.middleware.multipart-params.temp-file store."
+  (->Upload {:filename s/Str
+             :content-type s/Str
+             :size s/Int
+             (s/optional-key :tempfile) File}))
+
+(def ByteArrayUpload
+  "Schema for file param created by ring.middleware.multipart-params.byte-array store."
+  (->Upload {:filename s/Str
+             :content-type s/Str
+             :bytes s/Any}))

--- a/test/kekkonen/swagger_test.clj
+++ b/test/kekkonen/swagger_test.clj
@@ -5,14 +5,16 @@
             [schema.core :as s]
             [ring.util.http-response :refer [ok]]
             [plumbing.core :as p]
-            [kekkonen.ring :as r]
+            [kekkonen.ring :as ring]
             [kekkonen.common :as kc]))
 
 (p/defnk ^:handler echo
   {:summary "summary"
    :responses {200 {:schema {:x [s/Str]
                              :y s/Int
-                             :z s/Bool}}}}
+                             :z s/Bool}}}
+   ::ring/consumes ["application/json"]
+   ::ring/produces ["application/json"]}
   [[:request
     body-params :- {:country (s/enum :FI :CA)}
     [:query-params x :- [s/Str]]
@@ -24,9 +26,9 @@
   (let [dispatcher (k/transform-handlers
                      (k/dispatcher
                        (kc/merge-map-like
-                         r/+ring-dispatcher-options+
+                         ring/+ring-dispatcher-options+
                          {:handlers {:api {:admin #'echo}}}))
-                     (partial #'r/attach-ring-meta r/+default-options+))
+                     (partial #'ring/attach-ring-meta ring/+default-options+))
         handlers (k/available-handlers dispatcher nil {})
 
         swagger (ks/ring-swagger
@@ -50,6 +52,8 @@
                             :responses {200 {:schema {:x [s/Str]
                                                       :y s/Int
                                                       :z s/Bool}}}
+                            :consumes ["application/json"]
+                            :produces ["application/json"]
                             :summary "summary"
                             :tags [:api.admin]}}}})
 
@@ -61,9 +65,9 @@
   (let [dispatcher (k/transform-handlers
                      (k/dispatcher
                        (kc/merge-map-like
-                         r/+ring-dispatcher-options+
+                         ring/+ring-dispatcher-options+
                          {:handlers {:api {:admin #'echo}}}))
-                     (partial #'r/attach-ring-meta r/+default-options+))
+                     (partial #'ring/attach-ring-meta ring/+default-options+))
         swagger-handler (ks/swagger-handler {} {:spec "swagger.json", :info {:version "1.2.3"}})]
 
     (against-background [(k/get-dispatcher anything) => dispatcher]


### PR DESCRIPTION
* add `:kekkonen.ring/produces` and `:kekkonen.ring/consumes` => just for documentation purposes for now
* `kekkonen.upload` namespace with the needed plumbing
* current way to do swagger-aware upload:

```clj
(defnk upload
  "upload a file to the server"
  {:interceptors [[upload/multipart-params]]
   :type ::ring/handler
   ::ring/method :put
   ::ring/consumes ["multipart/form-data"]}
  [[:request [:multipart-params file :- upload/TempFileUpload]]]
  (success (dissoc file :tempfile)))
```

* TODO: simplify.