### PR TITLE
(WIP) Update muuntaja to 0.3.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
                  [metosin/ring-swagger-ui "2.2.8"]
                  [metosin/ring-http-response "0.8.1"]
                  [ring-middleware-format "0.7.0"]
-                 [metosin/muuntaja "0.1.0"]
+                 [metosin/muuntaja "0.3.0-SNAPSHOT"]
                  [ring/ring-defaults "0.2.1"]
 
                  ;; client stuff, separate module?

--- a/test/kekkonen/api_test.clj
+++ b/test/kekkonen/api_test.clj
@@ -219,17 +219,13 @@
                             :version "0.0.1"}
                      :consumes (just
                                  ["application/json"
-                                  "application/x-yaml"
                                   "application/edn"
-                                  "application/msgpack"
                                   "application/transit+json"
                                   "application/transit+msgpack"]
                                  :in-any-order)
                      :produces (just
                                  ["application/json"
-                                  "application/x-yaml"
                                   "application/edn"
-                                  "application/msgpack"
                                   "application/transit+json"
                                   "application/transit+msgpack"]
                                  :in-any-order)

--- a/test/kekkonen/middleware_test.clj
+++ b/test/kekkonen/middleware_test.clj
@@ -9,8 +9,7 @@
             [ring.util.http-predicates :as hp]
             [plumbing.core :as p]
             [kekkonen.common :as kc]
-            [muuntaja.core :as muuntaja]
-            [muuntaja.options :as options]))
+            [muuntaja.core :as muuntaja]))
 
 (p/defnk ^:handler plus
   [[:request [:query-params x :- s/Int, y :- s/Int]]]
@@ -54,7 +53,7 @@
 
 (facts "api-info"
   (let [options {:formats (muuntaja/create
-                            (options/formats
+                            (muuntaja/select-formats
                               muuntaja/default-options
                               ["application/json"
                                "application/transit+json"


### PR DESCRIPTION
This updates master to [Muuntaja 0.3.0-SNAPSHOT](https://github.com/metosin/muuntaja/blob/master/CHANGELOG.md#030-snapshot). Once Muuntaja 0.3.0 is released, let's upgrade to it. Then we can release Kekkonen 0.4.0 and master should be again in reasonable state for future development.