### PR TITLE
Remove the dependency on ring-middleware-format

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* Remove the dependency on `ring-middleware-format`, for real this time.
+
 ## 0.5.0 (2019-11-01)
 
 * Make Kekkonen compatible with Cloverage.

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ No. But we might integrate into [Pulsar](https://github.com/puniverse/pulsar).
 - [Plumbing](https://github.com/Prismatic/plumbing) for the `fnk`y syntax
 - [Fnhouse](https://github.com/Prismatic/fnhouse) for inspiration and reused ideas
 - [Ring-swagger](https://github.com/metosin/ring-swagger) for the Schema2Swagger -bindings
-- [Ring-middleware-format](https://github.com/ngrunwald/ring-middleware-format) for all the data formats
+- [Muuntaja](https://github.com/metosin/muuntaja) for all the data formats
 - [Compojure-api](https://github.com/metosin/compojure-api) for some middleware goodies
 
 ## License

--- a/modules/kekkonen-core/project.clj
+++ b/modules/kekkonen-core/project.clj
@@ -13,7 +13,6 @@
                  [metosin/ring-swagger]
                  [metosin/ring-swagger-ui]
                  [metosin/ring-http-response]
-                 [ring-middleware-format]
                  [metosin/muuntaja]
                  [ring/ring-defaults]
 

--- a/modules/kekkonen-core/src/kekkonen/middleware.clj
+++ b/modules/kekkonen-core/src/kekkonen/middleware.clj
@@ -1,7 +1,5 @@
 (ns kekkonen.middleware
-  (:require [ring.middleware.format-params :refer [wrap-restful-params]]
-            [ring.middleware.format-response :refer [wrap-restful-response]]
-            ring.middleware.http-response
+  (:require ring.middleware.http-response
             [ring.util.http-response :as r]
             [ring.middleware.keyword-params :refer [wrap-keyword-params]]
             [ring.middleware.nested-params :refer [wrap-nested-params]]
@@ -79,16 +77,8 @@
           (default-handler (:throwable &throw-context) nil request))))))
 
 ;;
-;; ring-middleware-format stuff
+;; Muuntaja stuff
 ;;
-
-(defn- handle-req-error [^Throwable e _ _]
-  ;; Ring-middleware-format catches all exceptions in req handling,
-  ;; i.e. (handler req) is inside try-catch. If r-m-f was changed to catch only
-  ;; exceptions from parsing the request, we wouldn't need to check the exception class.
-  (if (or (instance? JsonParseException e) (instance? ParserException e))
-    (slingshot/throw+ {:type :kekkonen.ring/parsing} e)
-    (slingshot/throw+ e)))
 
 (defn create-muuntaja [options]
   (if options

--- a/project.clj
+++ b/project.clj
@@ -27,7 +27,7 @@
                                   "modules/kekkonen-core/src"]
                    :dependencies [[org.clojure/clojure "1.10.1"]
                                   [criterium "0.4.4"]
-                                  [http-kit "2.2.0"]
+                                  [http-kit "2.3.0"]
                                   [midje "1.9.9"]
 
                                   [prismatic/plumbing]

--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,6 @@
                          [metosin/ring-swagger "0.24.0"]
                          [metosin/ring-swagger-ui "2.2.10"]
                          [metosin/ring-http-response "0.9.0"]
-                         [ring-middleware-format "0.7.4"]
                          [metosin/muuntaja "0.3.1"]
                          [ring/ring-defaults "0.3.0"]
 
@@ -25,6 +24,8 @@
                              [lein-midje "3.2.1"]]
                    :source-paths ["dev-src" "modules/kekkonen-core/src"]
                    :dependencies [[metosin/kekkonen]
+
+                                  [clj-kondo "RELEASE"]
 
                                   [org.clojure/clojure "1.10.1"]
                                   [criterium "0.4.4"]

--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                          [frankiesardo/linked "1.2.9"]
 
                          ;; http-stuff, separate module?
+                         [clj-commons/clj-yaml "0.7.0"]
                          [metosin/ring-swagger "0.24.0"]
                          [metosin/ring-swagger-ui "2.2.10"]
                          [metosin/ring-http-response "0.9.0"]
@@ -22,18 +23,27 @@
                          [clj-http "2.3.0"]]
   :profiles {:dev {:plugins [[lein-cloverage "1.0.10"]
                              [lein-midje "3.2.1"]]
-                   :source-paths ["dev-src" "modules/kekkonen-core/src"]
-                   :dependencies [[metosin/kekkonen]
-
-                                  [clj-kondo "RELEASE"]
-
-                                  [org.clojure/clojure "1.10.1"]
+                   :source-paths ["dev-src"
+                                  "modules/kekkonen-core/src"]
+                   :dependencies [[org.clojure/clojure "1.10.1"]
                                   [criterium "0.4.4"]
                                   [http-kit "2.2.0"]
+                                  [midje "1.9.9"]
+
+                                  [prismatic/plumbing]
+                                  [prismatic/schema]
+                                  [frankiesardo/linked]
+
+                                  [clj-commons/clj-yaml]
+                                  [metosin/muuntaja]
+                                  [metosin/ring-http-response]
+                                  [metosin/ring-swagger]
+                                  [metosin/ring-swagger-ui]
+
+                                  [clj-http] 
 
                                   ; uploads
-                                  [javax.servlet/servlet-api "2.5"]
-                                  [midje "1.9.9"]]}
+                                  [javax.servlet/servlet-api "2.5"]]}
              :perf {:jvm-opts ^:replace ["-Dclojure.compiler.direct-linking=true"]}
              :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}}


### PR DESCRIPTION
It was supposed to be removed, but it was still lurking there.